### PR TITLE
Declare Norm Statuses Explicitly

### DIFF
--- a/exec/grid_fit.cc
+++ b/exec/grid_fit.cc
@@ -150,6 +150,8 @@ void grid_fit(const std::string &fitConfigFile_,
   std::vector<BinnedED> pdfs;
   std::vector<int> genRates;
   std::vector<std::vector<std::string>> pdfGroups;
+  std::vector<NormFittingStatus> *norm_fitting_statuses;
+  norm_fitting_statuses->clear();
 
   // Create the empty full dist
   BinnedED asimov = BinnedED("asimov", systAxes);
@@ -199,6 +201,7 @@ void grid_fit(const std::string &fitConfigFile_,
     if (dist.Integral())
       dist.Normalise();
     pdfs.push_back(dist);
+    norm_fitting_statuses->push_back(INDIRECT);
 
     // Apply nominal systematic variables
     for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)    
@@ -267,7 +270,7 @@ void grid_fit(const std::string &fitConfigFile_,
   for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)
     lh.AddSystematic(it->second, systGroup[it->first]);
   // Add our pdfs
-  lh.AddPdfs(pdfs, pdfGroups, genRates);
+  lh.AddPdfs(pdfs, pdfGroups, genRates, norm_fitting_statuses);
   // And constraints
   for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
     lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));

--- a/exec/grid_llhscan.cc
+++ b/exec/grid_llhscan.cc
@@ -152,6 +152,8 @@ void grid_llhscan(const std::string &fitConfigFile_,
   std::vector<BinnedED> pdfs;
   std::vector<int> genRates;
   std::vector<std::vector<std::string>> pdfGroups;
+  std::vector<NormFittingStatus> *norm_fitting_statuses;
+  norm_fitting_statuses->clear();
 
   // Create the empty full dist
   BinnedED asimov = BinnedED("asimov", systAxes);
@@ -269,6 +271,7 @@ void grid_llhscan(const std::string &fitConfigFile_,
     if (dist.Integral())
       dist.Normalise();
     pdfs.push_back(dist);
+    norm_fitting_statuses->push_back(INDIRECT);
 
     // Apply nominal systematic variables
     for (std::map<std::string, Systematic *>::iterator systIt = systMap.begin(); systIt != systMap.end(); ++systIt)
@@ -353,7 +356,7 @@ void grid_llhscan(const std::string &fitConfigFile_,
   for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)
     lh.AddSystematic(it->second, systGroup[it->first]);
   // Add our pdfs
-  lh.AddPdfs(pdfs, pdfGroups, genRates);
+  lh.AddPdfs(pdfs, pdfGroups, genRates, norm_fitting_statuses);
   // And constraints
   for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
     lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
@@ -431,6 +434,7 @@ void grid_llhscan(const std::string &fitConfigFile_,
     // Now build a second likelihood for varying oscillation params
     // If we use the same one we have problems because the most PDFs are shrunk but the reactor one isn't
     BinnedNLLH osclh;
+    osclh.SetBuffer("energy",1,14);
     // Add our 'data'
     osclh.SetDataDist(dataDist);
 
@@ -447,7 +451,7 @@ void grid_llhscan(const std::string &fitConfigFile_,
       else
         pdfvec.push_back(oscPDFs.at(iDeltaM));
     }
-    osclh.AddPdfs(pdfvec, pdfGroups, genRates);
+    osclh.AddPdfs(pdfvec, pdfGroups, genRates, norm_fitting_statuses);
 
     // And set any constraints
     for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
@@ -476,6 +480,7 @@ void grid_llhscan(const std::string &fitConfigFile_,
     // Now build a second likelihood for varying oscillation params
     // If we use the same one we have problems because the most PDFs are shrunk but the reactor one isn't
     BinnedNLLH osclh;
+    osclh.SetBuffer("energy",1,14);
     // Add our 'data'
     osclh.SetDataDist(dataDist);
 
@@ -492,7 +497,7 @@ void grid_llhscan(const std::string &fitConfigFile_,
       else
         pdfvec.push_back(oscPDFs.at(iTheta12 + npoints));
     }
-    osclh.AddPdfs(pdfvec, pdfGroups, genRates);
+    osclh.AddPdfs(pdfvec, pdfGroups, genRates, norm_fitting_statuses);
 
     // And set any constraints
     for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)

--- a/exec/llh_scan.cc
+++ b/exec/llh_scan.cc
@@ -146,6 +146,8 @@ void llh_scan(const std::string &fitConfigFile_,
   std::vector<BinnedED> pdfs;
   std::vector<int> genRates;
   std::vector<std::vector<std::string>> pdfGroups;
+  std::vector<NormFittingStatus> *norm_fitting_statuses;
+  norm_fitting_statuses->clear();
 
   // Create the empty full dist
   BinnedED asimov = BinnedED("asimov", systAxes);
@@ -185,6 +187,7 @@ void llh_scan(const std::string &fitConfigFile_,
     if (dist.Integral())
       dist.Normalise();
     pdfs.push_back(dist);
+    norm_fitting_statuses->push_back(INDIRECT);
 
     // Apply nominal systematic variables
     for (std::map<std::string, Systematic *>::iterator systIt = systMap.begin(); systIt != systMap.end(); ++systIt)
@@ -252,7 +255,7 @@ void llh_scan(const std::string &fitConfigFile_,
   for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)
     lh.AddSystematic(it->second, systGroup[it->first]);
   // Add our pdfs
-  lh.AddPdfs(pdfs, pdfGroups, genRates);
+  lh.AddPdfs(pdfs, pdfGroups, genRates, norm_fitting_statuses);
   // And constraints
   for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
     lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));

--- a/exec/mcmc.cc
+++ b/exec/mcmc.cc
@@ -163,6 +163,8 @@ void mcmc(const std::string &fitConfigFile_,
   std::vector<BinnedED> pdfs;
   std::vector<int> genRates;
   std::vector<std::vector<std::string>> pdfGroups;
+  std::vector<NormFittingStatus> *norm_fitting_statuses;
+  norm_fitting_statuses->clear();
 
   // Create the empty full dist
   BinnedED asimov = BinnedED("asimov", systAxes);
@@ -202,6 +204,7 @@ void mcmc(const std::string &fitConfigFile_,
     if (dist.Integral())
       dist.Normalise();
     pdfs.push_back(dist);
+    norm_fitting_statuses->push_back(INDIRECT);
 
     // Apply nominal systematic variables
     for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)
@@ -269,7 +272,7 @@ void mcmc(const std::string &fitConfigFile_,
   for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)
     lh.AddSystematic(it->second, systGroup[it->first]);
   // Add our pdfs
-  lh.AddPdfs(pdfs, pdfGroups, genRates);
+  lh.AddPdfs(pdfs, pdfGroups, genRates, norm_fitting_statuses);
   // And constraints
   for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
     lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));


### PR DESCRIPTION
The norm statuses in OXO default to FALSE not INDIRECT so we need to tell it what we want it to do.

Also, when you declare a `std::vector<NormFittingStatus> *norm_fitting_statuses;` it initially has 4 elements (not sure what/why). So if we loop over PDFs, pushing back a norm status each time, they get added after those 4. So in this PR I clear out that vector after declaring