### PR TITLE
Remove PDF Dir from PDF Config

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -116,7 +116,6 @@ This file should contain information on the pdf axes. An example is shown in `cf
   
 - `build_order`: The axes used for the PDFs. These will be defined in the same file as axis tables. The order is important: the dimensions field in `events` config sets the number of dimensions, N, for a given PDF. The axes used will be the first N axes here
 - `data_axes`: The axes the data will have
-- `pdf_dir`: Where the PDFs should be saved to as histograms
 
 <h5>PDF Axis Tables</h5>
   

--- a/cfg/pdf_config.ini.template
+++ b/cfg/pdf_config.ini.template
@@ -1,7 +1,6 @@
 [summary]
 build_order = energy,reactor,nu_energy
 data_axes = energy
-pdf_dir =
 
 [energy]
 n_bins=140

--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -23,10 +23,10 @@
 using namespace antinufit;
 
 void fixedosc_fit(const std::string &fitConfigFile_,
-              const std::string &evConfigFile_,
-              const std::string &pdfConfigFile_,
-              const std::string &systConfigFile_,
-              const std::string &oscGridConfigFile_)
+                  const std::string &evConfigFile_,
+                  const std::string &pdfConfigFile_,
+                  const std::string &systConfigFile_,
+                  const std::string &oscGridConfigFile_)
 {
   Rand::SetSeed(0);
 
@@ -55,8 +55,11 @@ void fixedosc_fit(const std::string &fitConfigFile_,
     mkdir(outDir.c_str(), 0700);
 
   std::string scaledDistDir = outDir + "/scaled_dists";
+  std::string pdfDir = outDir + "/pdfs";
   if (stat(scaledDistDir.c_str(), &st) == -1)
     mkdir(scaledDistDir.c_str(), 0700);
+  if (stat(pdfDir.c_str(), &st) == -1)
+    mkdir(pdfDir.c_str(), 0700);
 
   // Load up all the event types we want to contribute
   typedef std::map<std::string, EventConfig> EvMap;
@@ -66,7 +69,6 @@ void fixedosc_fit(const std::string &fitConfigFile_,
   // Load up the PDF information (skeleton axis details, rather than the distributions themselves)
   PDFConfigLoader pdfLoader(pdfConfigFile_);
   PDFConfig pdfConfig = pdfLoader.Load();
-  std::string pdfDir = pdfConfig.GetPDFDir();
   std::vector<std::string> dataObs = pdfConfig.GetDataBranchNames();
   ObsSet dataObsSet(dataObs);
   AxisCollection systAxes = DistBuilder::BuildAxes(pdfConfig, dataObs.size());

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -52,6 +52,10 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   if (stat(outDir.c_str(), &st) == -1)
     mkdir(outDir.c_str(), 0700);
 
+  std::string pdfDir = outDir + "/pdfs";
+  if (stat(pdfDir.c_str(), &st) == -1)
+    mkdir(pdfDir.c_str(), 0700);
+
   // Load up all the event types we want to contribute
   typedef std::map<std::string, EventConfig> EvMap;
   EventConfigLoader loader(evConfigFile_);
@@ -60,7 +64,6 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   // Load up the PDF information (skeleton axis details, rather than the distributions themselves)
   PDFConfigLoader pdfLoader(pdfConfigFile_);
   PDFConfig pdfConfig = pdfLoader.Load();
-  std::string pdfDir = pdfConfig.GetPDFDir();
   std::vector<std::string> dataObs = pdfConfig.GetDataBranchNames();
   ObsSet dataObsSet(dataObs);
   AxisCollection systAxes = DistBuilder::BuildAxes(pdfConfig, dataObs.size());

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -489,14 +489,14 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   // Now we do the same for the oscillation parameters
 
   // And a bit of jiggery pokery here to guarantee that the nominal value is one of the scan points
-  double width = (deltam21_max - deltam21_max) / (npoints);
+  double width = (deltam21_max - deltam21_min) / (npoints);
   int numStepsBelowNom = floor((deltam21_nom - deltam21_min) / width);
   int numStepsAboveNom = floor((deltam21_max - deltam21_nom) / width);
   double min = deltam21_nom - numStepsBelowNom * width;
   double max = deltam21_nom + numStepsAboveNom * width;
 
   TString htitle = Form("%s, Nom. Value: %f", "deltam21", deltam21_nom);
-  TH1D *hDeltam = new TH1D("deltam21_full", "deltam21_full", npoints, (min - (width / 2)) / deltam21_nom, (max + (width / 2)) / deltam21_nom);
+  TH1D *hDeltam = new TH1D("deltam21_full", "deltam21_full", npoints, (min - (width / 2)), (max + (width / 2)));
   hDeltam->SetTitle(std::string(htitle + "; #Delta m^{2}_{21} (eV^{2}); -(ln L_{full})").c_str());
 
   std::cout << "Scanning for deltam21" << std::endl;
@@ -552,7 +552,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
 
   // Repeat for theta
   htitle = Form("%s, Nom. Value: %f", "theta12", theta12_nom);
-  TH1D *hTheta12 = new TH1D("theta12_nom_full", "theta12_nom_full", npoints, (min - (width / 2)) / theta12_nom, (max + (width / 2)) / theta12_nom);
+  TH1D *hTheta12 = new TH1D("theta12_nom_full", "theta12_nom_full", npoints, (min - (width / 2)), (max + (width / 2)));
   hTheta12->SetTitle(std::string(htitle + "; #theta_{12} (^{o}); -(ln L_{full})").c_str());
   std::cout << "Scanning for theta12" << std::endl;
   for (int iTheta12 = 0; iTheta12 < npoints; iTheta12++)

--- a/exec/llh_scan.cc
+++ b/exec/llh_scan.cc
@@ -47,9 +47,14 @@ void llh_scan(const std::string &fitConfigFile_,
   std::map<std::string, std::string> constrRatioParName = fitConfig.GetConstrRatioParName();
   ParameterDict fdValues = fitConfig.GetFakeDataVals();
 
+  // Create output directories
   struct stat st = {0};
   if (stat(outDir.c_str(), &st) == -1)
     mkdir(outDir.c_str(), 0700);
+
+  std::string pdfDir = outDir + "/pdfs";
+  if (stat(pdfDir.c_str(), &st) == -1)
+    mkdir(pdfDir.c_str(), 0700);
 
   // Load up all the event types we want to contribute
   typedef std::map<std::string, EventConfig> EvMap;
@@ -59,7 +64,6 @@ void llh_scan(const std::string &fitConfigFile_,
   // Load up the PDF information (skeleton axis details, rather than the distributions themselves)
   PDFConfigLoader pdfLoader(pdfConfigFile_);
   PDFConfig pdfConfig = pdfLoader.Load();
-  std::string pdfDir = pdfConfig.GetPDFDir();
   std::vector<std::string> dataObs = pdfConfig.GetDataBranchNames();
   ObsSet dataObsSet(dataObs);
   AxisCollection systAxes = DistBuilder::BuildAxes(pdfConfig, dataObs.size());
@@ -355,7 +359,7 @@ void llh_scan(const std::string &fitConfigFile_,
 
     // Make histogram for this parameter
     TString htitle = Form("%s, Asimov Rate: %f", name.c_str(), nom);
-    TH1D *hScan = new TH1D((name + "_full").c_str(), (name + "_full").c_str(), npoints, (min-(width/2)) / nom, (max+(width/2)) / nom);
+    TH1D *hScan = new TH1D((name + "_full").c_str(), (name + "_full").c_str(), npoints, (min - (width / 2)) / nom, (max + (width / 2)) / nom);
     hScan->SetTitle(std::string(htitle + ";" + name + " (rel. to Asimov); -(ln L_{full})").c_str());
 
     // Now loop from min to max in npoint steps

--- a/exec/mcmc.cc
+++ b/exec/mcmc.cc
@@ -59,12 +59,15 @@ void mcmc(const std::string &fitConfigFile_,
   std::string projDir1D = outDir + "/1dlhproj";
   std::string projDir2D = outDir + "/2dlhproj";
   std::string scaledDistDir = outDir + "/scaled_dists";
+  std::string pdfDir = outDir + "/pdfs";
   if (stat(projDir1D.c_str(), &st) == -1)
     mkdir(projDir1D.c_str(), 0700);
   if (stat(projDir2D.c_str(), &st) == -1)
     mkdir(projDir2D.c_str(), 0700);
   if (stat(scaledDistDir.c_str(), &st) == -1)
     mkdir(scaledDistDir.c_str(), 0700);
+  if (stat(pdfDir.c_str(), &st) == -1)
+    mkdir(pdfDir.c_str(), 0700);
 
   // Load up all the event types we want to contribute
   typedef std::map<std::string, EventConfig> EvMap;
@@ -74,7 +77,6 @@ void mcmc(const std::string &fitConfigFile_,
   // Load up the PDF information (skeleton axis details, rather than the distributions themselves)
   PDFConfigLoader pdfLoader(pdfConfigFile_);
   PDFConfig pdfConfig = pdfLoader.Load();
-  std::string pdfDir = pdfConfig.GetPDFDir();
   std::vector<std::string> dataObs = pdfConfig.GetDataBranchNames();
   ObsSet dataObsSet(dataObs);
   AxisCollection systAxes = DistBuilder::BuildAxes(pdfConfig, dataObs.size());

--- a/src/config/PDFConfig.cc
+++ b/src/config/PDFConfig.cc
@@ -46,18 +46,6 @@ namespace antinufit
     fMaxima.push_back(max_);
   }
 
-  const std::string &
-  PDFConfig::GetPDFDir() const
-  {
-    return fPDFDir;
-  }
-
-  void
-  PDFConfig::SetPDFDir(const std::string &s_)
-  {
-    fPDFDir = s_;
-  }
-
   std::vector<std::string>
   PDFConfig::GetBranchNames() const
   {

--- a/src/config/PDFConfig.hh
+++ b/src/config/PDFConfig.hh
@@ -21,9 +21,6 @@ namespace antinufit
                  const std::string &texName_,
                  int binCount_, double min_, double max_);
 
-    const std::string &GetPDFDir() const;
-    void SetPDFDir(const std::string &);
-
     const std::vector<std::string> &GetDataBranchNames() const;
     void SetDataBranchNames(const std::vector<std::string> &);
 
@@ -31,7 +28,6 @@ namespace antinufit
     std::vector<std::string> GetBranchNames( const int ) const;
 
   private:
-    std::string fPDFDir;
     std::vector<std::string> fAxisNames;
     std::vector<std::string> fDataAxesNames;
     std::vector<std::string> fBranchNames;

--- a/src/config/PDFConfigLoader.cc
+++ b/src/config/PDFConfigLoader.cc
@@ -22,9 +22,6 @@ namespace antinufit
     std::vector<std::string> data_axes;
     ConfigLoader::Load("summary", "data_axes", data_axes);
 
-    std::string pdfDir;
-    ConfigLoader::Load("summary", "pdf_dir", pdfDir);
-
     PDFConfig retVal;
 
     double min;
@@ -47,7 +44,6 @@ namespace antinufit
       ConfigLoader::Load(name, "tex_name", texName);
       retVal.AddAxis(name, branchName, texName, binCount, min, max);
     }
-    retVal.SetPDFDir(pdfDir);
     retVal.SetDataBranchNames(data_axes);
     return retVal;
   }


### PR DESCRIPTION
Currently, when you run a fit or llh the pdfs are saved in a directory set in the pdf config. This is a hangover from the old double beta repo where the workflow was to make the pdfs independently from the fit.

Nowadays, the PDFs are built at run time so we can guarantee the Asimov dataset is exactly what goes into the fit, and if you want to change something you don't have to rerun separate code to make the PDFs.

But it's cumbersome having to update a path in the fit config and in the pdf config every time you run, so here I remove the pdf dir from the pdf config, and in the apps I save the pdf histograms in a directory called "pdfs" under the output directory 

It builds on PR 6 so I'll get that merged in first