### PR TITLE
Scale Reactor Constraint by Ratio of Oscillated to Unoscillated Number of Events

### DIFF
--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -190,7 +190,13 @@ void fixedosc_fit(const std::string &fitConfigFile_,
     if (it->first == "reactor_nubar")
     {
       // Build the distribution with oscillation parameters at their nominal values
-      dist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21, theta12, indexDistance);
+      double ratio = 1.0;
+      dist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21, theta12, indexDistance, ratio);
+
+      // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
+      constrMeans[it->first] = constrMeans[it->first] * ratio;
+      constrSigmas[it->first] = constrSigmas[it->first] * ratio;
+      noms[it->first] = noms[it->first] * ratio;
     }
     else
     {

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -211,14 +211,27 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
     {
       reacPDFNum = pdfs.size();
       // Build the distribution with oscillation parameters at their nominal values
-      dist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21_nom, theta12_nom, indexDistance);
+      // Pass double by reference here to get ratio of unoscillated to oscillated events
+      double ratio = 1.0;
+      dist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21_nom, theta12_nom, indexDistance, ratio);
+
+      // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
+      constrMeans[it->first] = constrMeans[it->first] * ratio;
+      constrSigmas[it->first] = constrSigmas[it->first] * ratio;
+      noms[it->first] = noms[it->first] * ratio;
 
       // Now loop over deltam points and make a new pdf for each
       for (int iDeltaM = 0; iDeltaM < npoints; iDeltaM++)
       {
         double deltam21 = deltam21_min + (double)iDeltaM * (deltam21_max - deltam21_min) / (npoints - 1);
         std::cout << "Loading " << it->second.GetPrunedPath() << " deltam21: " << deltam21 << ", theta12: " << theta12_nom << std::endl;
-        BinnedED oscDist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21, theta12_nom, indexDistance);
+        BinnedED oscDist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21, theta12_nom, indexDistance, ratio);
+
+        // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
+        constrMeans[it->first] = constrMeans[it->first] * ratio;
+        constrSigmas[it->first] = constrSigmas[it->first] * ratio;
+        noms[it->first] = noms[it->first] * ratio;
+
         oscDist.AddPadding(1E-6);
         oscDist.Normalise();
         oscPDFs.push_back(oscDist);
@@ -243,7 +256,13 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       {
         double theta12 = theta12_min + (double)iTheta * (theta12_max - theta12_min) / (npoints - 1);
         std::cout << "Loading " << it->second.GetPrunedPath() << " deltam21: " << deltam21_nom << ", theta12: " << theta12 << std::endl;
-        BinnedED oscDist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21_nom, theta12, indexDistance);
+        BinnedED oscDist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21_nom, theta12, indexDistance, ratio);
+
+        // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
+        constrMeans[it->first] = constrMeans[it->first] * ratio;
+        constrSigmas[it->first] = constrSigmas[it->first] * ratio;
+        noms[it->first] = noms[it->first] * ratio;
+
         oscDist.AddPadding(1E-6);
         oscDist.Normalise();
         oscPDFs.push_back(oscDist);

--- a/src/util/DistBuilder.cc
+++ b/src/util/DistBuilder.cc
@@ -64,7 +64,7 @@ namespace antinufit
   }
 
   BinnedED
-  DistBuilder::BuildOscillatedDist(const std::string &name_, const int numDimensions_, const PDFConfig pdfConfig_, DataSet *data_, double deltam21_, double theta12_, std::unordered_map<int, double> indexDistance_)
+  DistBuilder::BuildOscillatedDist(const std::string &name_, const int numDimensions_, const PDFConfig pdfConfig_, DataSet *data_, double deltam21_, double theta12_, std::unordered_map<int, double> indexDistance_, double& ratio)
   {
     // Create the axes
     AxisCollection axes = BuildAxes(pdfConfig_, numDimensions_);
@@ -90,6 +90,8 @@ namespace antinufit
         dist.Fill(ev);
       }
     }
+
+    ratio = dist.Integral() / data_->GetNEntries();
 
     return dist;
   }

--- a/src/util/DistBuilder.hh
+++ b/src/util/DistBuilder.hh
@@ -30,7 +30,7 @@ namespace antinufit
   public:
     static BinnedED Build(const std::string &name, const int, const PDFConfig , DataSet *data_);
     static BinnedED Build(const std::string &name, const PDFConfig , DataSet *data_);
-    static BinnedED BuildOscillatedDist(const std::string &, const int, const PDFConfig, DataSet*, double, double, std::unordered_map<int, double>);
+    static BinnedED BuildOscillatedDist(const std::string &, const int, const PDFConfig, DataSet*, double, double, std::unordered_map<int, double>, double &);
     static AxisCollection BuildAxes(const PDFConfig &, const int);
     static AxisCollection BuildAxes(const PDFConfig &);
   };


### PR DESCRIPTION
The unoscillated number of reactor events is the initial fit parameter entered in the fit config

Then we scale this (and any constraint) by the ratio of the number of oscillated to unoscillated number of events, as calculated in the dist builder