### PR TITLE
Be compatible for num of Reactornu varaition when osc pars change

### DIFF
--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -197,6 +197,9 @@ void fixedosc_fit(const std::string &fitConfigFile_,
       constrMeans[it->first] = constrMeans[it->first] * ratio;
       constrSigmas[it->first] = constrSigmas[it->first] * ratio;
       noms[it->first] = noms[it->first] * ratio;
+      mins[it->first] = mins[it->first] * ratio;
+      maxs[it->first] = maxs[it->first] * ratio;
+      fdValues[it->first] = noms[it->first];
     }
     else
     {

--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -199,7 +199,7 @@ void fixedosc_fit(const std::string &fitConfigFile_,
       noms[it->first] = noms[it->first] * ratio;
       mins[it->first] = mins[it->first] * ratio;
       maxs[it->first] = maxs[it->first] * ratio;
-      fdValues[it->first] = noms[it->first];
+      fdValues[it->first] = fdValues[it->first] * ratio;
     }
     else
     {

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -128,7 +128,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   double theta12_max = maxs["theta12"];
 
   // Define the number of points
-  int npoints =150;
+  int npoints = 150;
   int countwidth = double(npoints) / double(5);
 
   // A parameter could have been defined in the fit config but isn't associated with a pdf or systematic
@@ -207,7 +207,6 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
 
     // If it's the reactor PDF, two things are different from the others. Firstly we use the BuildOscillatedDist rather than just Build.
     // Also, we're going to loop over oscillation scan points to make the reactor's PDF for that point as well
-    std::vector<double> constrMeans_Map;
     if (it->first == "reactor_nubar")
     {
       reacPDFNum = pdfs.size();
@@ -215,6 +214,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       // Pass double by reference here to get ratio of unoscillated to oscillated events
       double ratio = 1.0;
       dist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21_nom, theta12_nom, indexDistance, ratio);
+      
       // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
       
       double constrMeans_config = constrMeans[it->first];  
@@ -227,7 +227,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       noms[it->first] = noms_config * ratio;
       mins[it->first] = min_config * ratio;
       maxs[it->first] = max_config * ratio;
-      fdValues[it->first] = noms[it->first];
+      fdValues[it->first] = fdValues[it->first] *ratio;
       
       // Now loop over deltam points and make a new pdf for each
       for (int iDeltaM = 0; iDeltaM < npoints; iDeltaM++)

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -214,19 +214,15 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       // Pass double by reference here to get ratio of unoscillated to oscillated events
       double ratio = 1.0;
       dist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21_nom, theta12_nom, indexDistance, ratio);
-      
+
       // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
       
-      double constrMeans_config = constrMeans[it->first];  
-      double constrSigmas_config = constrSigmas[it->first];  
-      double noms_config        = noms[it->first];  
-      double min_config        = mins[it->first];  
-      double max_config        = maxs[it->first];  
-      constrMeans[it->first] = constrMeans_config * ratio;
-      constrSigmas[it->first] = constrSigmas_config * ratio;
+      double noms_config = noms[it->first];  
+      constrMeans[it->first] = constrMeans[it->first] * ratio;
+      constrSigmas[it->first] = constrSigmas[it->first] * ratio;
       noms[it->first] = noms_config * ratio;
-      mins[it->first] = min_config * ratio;
-      maxs[it->first] = max_config * ratio;
+      mins[it->first] = mins[it->first] * ratio;
+      maxs[it->first] = maxs[it->first] * ratio;
       fdValues[it->first] = fdValues[it->first] *ratio;
       
       // Now loop over deltam points and make a new pdf for each


### PR DESCRIPTION
After this change, in fixedosc_llhscan a clear absolute minimum can be seen for each fitting parameters for both Asmov and fakedataset trial, whereas in fixedosc_fit exec, the fit has been successfully done with corrected number of post-oscillated reactor nu for given pre-oscillated number.