### PR TITLE
Parameter Labels in Fit Config

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -63,7 +63,6 @@ This file should contain information on the types of events you want to include 
 <h5>Event Type Tables</h5>
 
 The name of these tables should be the name of the event type.
-- `tex_label`: A latex name for the event type
 - `ntup_files`: File path for the original unpruned files, relative to `orig_base_dir`
 - `dimensions`: Number of dimensions the PDF should have
 - `groups`: The groups the PDFs are part of. Each systematic is applied to one group (or all event types)
@@ -97,6 +96,7 @@ The name of these tables should be the name of the fit parameter.
 - `max`: The maximum value the parameter is allowed to take
 - `sig`: The relative width of the Gaussian used to propose new step values (each gets scaled by summary:sigma_scale). Often referred to as the step size
 - `nbins`: Number of bins used for plotting the parameter
+- `tex_label`: A latex name used for the parameter
 - `constraint_mean`: Mean of the prior constraint on the parameter
 - `constraint_sig`: Width of the prior constraint on the parameter
 - `constraint_ratiomean`: Mean of prior constraint on ratio of this parameter to another

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,9 @@ bin/make_plots: exec/make_plots.cc $(LIB)
 	mkdir -p bin
 	$(CXX)  exec/make_plots.cc $(INCLUDES) -w $(LIBRARYDIRS) $(LIBRARYNAMES) $(ROOT_FLAGS) $(G4_FLAGS) ${GSL_FLAGS} -larmadillo -o $@
 
-bin/makeFixedOscTree: util/makeFixedOscTree.cc $(LIB)
+bin/makeFixedOscTree: exec/makeFixedOscTree.cc $(LIB)
 	mkdir -p bin
-	$(CXX)  util/makeFixedOscTree.cc $(INCLUDES) -w $(LIBRARYDIRS) $(LIBRARYNAMES) $(ROOT_FLAGS) $(G4_FLAGS) ${GSL_FLAGS} -larmadillo -o $@
+	$(CXX)  exec/makeFixedOscTree.cc $(INCLUDES) -w $(LIBRARYDIRS) $(LIBRARYNAMES) $(ROOT_FLAGS) $(G4_FLAGS) ${GSL_FLAGS} -larmadillo -o $@
 
 $(LIB) : $(OBJ_FILES)
 	mkdir -p $(LIB_DIR)

--- a/cfg/event_config.ini.template
+++ b/cfg/event_config.ini.template
@@ -5,43 +5,36 @@ orig_base_dir=
 pruned_ntup_dir=
 
 [reactor_nubar]
-tex_label = Reactor-$\bar{\nu}$
 ntup_files =
 groups = osc_group,3d
 dimensions = 3
 
 [geonu_U]
-tex_label = U Geo $\bar{\nu}$
 ntup_files =
 dimensions = 1
 groups = 1d
 
 [geonu_Th]
-tex_label = Th Geo $\bar{\nu}$
 ntup_files =
 dimensions = 1
 groups = 1d
 
 [alphan_PRecoil]
-tex_label = $\alpha-n$ Proton Recoil
 ntup_files =
 groups = p_recoil,1d
 dimensions = 1
 
 [alphan_CScatter]
-tex_label = $\alpha-n$ Proton Ielastic Scatter
 ntup_files =
 dimensions = 1
 groups = 1d
 
 [alphan_OExcited]
-tex_label = $\alpha-n$ Excited $^{16}$O
 ntup_files =
 dimensions = 1
 groups = 1d
 
 [sideband]
-tex_label = Sideband
 ntup_files =
 dimensions = 1
 groups = 1d

--- a/cfg/fit_config.ini.template
+++ b/cfg/fit_config.ini.template
@@ -2,9 +2,11 @@
 datafile = 
 asimov = 1
 fake_data = 0
+livetime = 1
 iterations = 50000
 burn_in = 1000
 fit_dists = all
+save_outputs = 0
 output_directory =
 
 n_steps = 35
@@ -21,6 +23,9 @@ min = 0
 max = 100
 sig = 10
 nbins = 100
+tex_label = "Reactor #bar{#nu}"
+constraint_mean = 51.33
+constraint_sigma = 2.23
 
 [geonu_U]
 nom = 5.36
@@ -28,6 +33,10 @@ min = 0
 max = 100
 sig = 10
 nbins = 100
+tex_label = "U Geo #bar{#nu}"
+constraint_ratiomean = 3.7
+constraint_ratiosigma = 1.3
+constraint_ratioparname = geonu_Th
 
 [geonu_Th]
 nom = 1.44
@@ -35,6 +44,7 @@ min = 0
 max = 100
 sig = 10
 nbins = 100
+tex_label = "Th Geo #bar{#nu}"
 
 [alphan_PRecoil]
 nom = 0.86
@@ -42,6 +52,9 @@ min = 0
 max = 100
 sig = 10
 nbins = 100
+tex_label = "#alpha-n P Recoil"
+constraint_mean = 15.62
+constraint_sigma = 4.69
 
 [alphan_CScatter]
 nom = 0.028
@@ -49,6 +62,9 @@ min = 0
 max = 100
 sig = 10
 nbins = 100
+tex_label = "#alpha-n C Scatter"
+constraint_mean = 0.4
+constraint_sigma = 0.12
 
 [alphan_OExcited]
 nom = 0.12
@@ -56,6 +72,19 @@ min = 0
 max = 100
 sig = 10
 nbins = 100
+tex_label = "#alpha-n O Excited"
+constraint_mean = 1.58
+constraint_sigma = 1.58
+
+[sideband]
+nom = 1.7
+min = 0
+max = 5
+sig = 1.
+nbins = 100
+tex_label = "Sideband"
+constraint_mean = 1.7
+constraint_sigma = 1.1
 
 [energy_scale]
 nom = 1.0
@@ -63,6 +92,7 @@ sig = 0.018
 min = 0.0
 max = 2.0
 nbins = 100
+tex_label = "Energy Scale"
 constraint_mean = 1.00
 constraint_sigma = 0.018
 
@@ -72,6 +102,7 @@ sig = 0.1
 min = 0
 max = 10
 nbins = 100
+tex_label = "Energy Conv."
 
 [energy_nonlin]
 nom = 0.074
@@ -79,6 +110,7 @@ sig = 0.004
 min = -10
 max = 10
 nbins = 100
+tex_label = "Birk's Constant"
 constraint_mean = 0.074
 constraint_sigma = 0.004
 
@@ -88,19 +120,25 @@ sig = 0.03
 min = 0.0
 max = 2.0
 nbins = 100
+tex_label = "E. Scale #alpha-n PR"
 constraint_mean = 1.00
-constraint_sigma = 0.03
+constraint_sigma = 0.1
 
 [theta12]
-nom = 99.1
-min = 0.0
-sig = 6.55
+nom = 33.65
+min = -0.01
 nbins = 100
-max = 180
+sig = 6.55
+max = 89.99
+fake_data_val = 33.65
+tex_label = "#theta_{12}"
+
 
 [deltam21]
 nom = 0.0000753
 sig = 0.0000018
-min = 0.00001
-max = 0.00015
+min = 0.00003002
+max = 0.00011002
 nbins = 100
+fake_data_val = 0.0000753
+tex_label = "#Delta m^{2}_{21}"

--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -511,7 +511,8 @@ void fixedosc_fit(const std::string &fitConfigFile_,
   std::cout << "deltam: " << deltam21 << std::endl;
   std::cout << "theta: " << theta12 << std::endl;
   std::cout << "LLH: " << finalLLH << std::endl;
-  std::cout << "FitValid: " << validFit << std::endl
+  std::cout << "FitValid: " << validFit << std::endl;
+  std::cout << "ReactorRatio: " << reactorRatio << std::endl
             << std::endl
             << std::endl;
 }

--- a/src/config/EventConfig.cc
+++ b/src/config/EventConfig.cc
@@ -16,18 +16,6 @@ namespace antinufit
   }
 
   std::string
-  EventConfig::GetTexLabel() const
-  {
-    return fTexLabel;
-  }
-
-  void
-  EventConfig::SetTexLabel(const std::string &s_)
-  {
-    fTexLabel = s_;
-  }
-
-  std::string
   EventConfig::GetName() const
   {
     return fName;

--- a/src/config/EventConfig.hh
+++ b/src/config/EventConfig.hh
@@ -18,9 +18,6 @@ namespace antinufit
     const std::vector<std::string> &GetNtupFiles() const;
     void SetNtupFiles(const std::vector<std::string> &);
 
-    std::string GetTexLabel() const;
-    void SetTexLabel(const std::string &);
-
     std::string GetNtupBaseDir() const;
     void SetNtupBaseDir(const std::string &);
 
@@ -37,7 +34,6 @@ namespace antinufit
     std::vector<std::string> fNtupFiles;
     std::string fNtupBaseDir; // The originals
     std::string fPrunedPath;  // The pruned ouput
-    std::string fTexLabel;
     std::string fName;
     std::vector<std::string> fGroup;
     int fNumDimensions;

--- a/src/config/EventConfigLoader.cc
+++ b/src/config/EventConfigLoader.cc
@@ -19,12 +19,10 @@ namespace antinufit
     ConfigLoader::Load("summary", "orig_base_dir", baseDir);
     ConfigLoader::Load("summary", "pruned_ntup_dir", prunedDir);
 
-    std::string texLabel;
     std::vector<std::string> ntupFiles;
     int numDimensions;
     std::vector<std::string> groups;
 
-    ConfigLoader::Load(name_, "tex_label", texLabel);
     ConfigLoader::Load(name_, "ntup_files", ntupFiles);
     ConfigLoader::Load(name_, "dimensions", numDimensions);
 
@@ -42,7 +40,6 @@ namespace antinufit
 
     EventConfig retVal;
     retVal.SetNtupFiles(ntupFiles);
-    retVal.SetTexLabel(texLabel);
     retVal.SetName(name_);
     retVal.SetNtupBaseDir(baseDir);
     retVal.SetPrunedPath(prunedDir + "/" + name_ + ".root");

--- a/src/config/FitConfig.cc
+++ b/src/config/FitConfig.cc
@@ -39,6 +39,12 @@ namespace antinufit
     return fNbins;
   }
 
+  std::map<std::string, std::string>
+  FitConfig::GetTexLabels() const
+  {
+    return fTexLabels;
+  }
+
   int FitConfig::GetIterations() const
   {
     return fIterations;
@@ -248,7 +254,7 @@ namespace antinufit
   }
 
   void
-  FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_, 
+  FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_,
                           std::string label_)
   {
     fMinima[name_] = min_;

--- a/src/config/FitConfig.cc
+++ b/src/config/FitConfig.cc
@@ -238,17 +238,18 @@ namespace antinufit
 
   void
   FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_,
-                          double constrMean_, double constrSigma_)
+                          std::string label_, double constrMean_, double constrSigma_)
   {
 
     fConstrMeans[name_] = constrMean_;
     fConstrSigmas[name_] = constrSigma_;
 
-    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_);
+    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_, label_);
   }
 
   void
-  FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_)
+  FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_, 
+                          std::string label_)
   {
     fMinima[name_] = min_;
     fMaxima[name_] = max_;
@@ -256,18 +257,19 @@ namespace antinufit
     fFakeDataVals[name_] = fdvalue_;
     fSigmas[name_] = sigma_;
     fNbins[name_] = nbins_;
+    fTexLabels[name_] = label_;
   }
 
   void
   FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_,
-                          double constrRatioMean_, double constrRatioSigma_, std::string constrRatioParName_)
+                          std::string label_, double constrRatioMean_, double constrRatioSigma_, std::string constrRatioParName_)
   {
 
     fConstrRatioMeans[name_] = constrRatioMean_;
     fConstrRatioSigmas[name_] = constrRatioSigma_;
     fConstrRatioParName[name_] = constrRatioParName_;
 
-    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_);
+    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_, label_);
   }
 
 }

--- a/src/config/FitConfig.hh
+++ b/src/config/FitConfig.hh
@@ -16,6 +16,7 @@ namespace antinufit
     ParameterDict GetNBins() const;
     ParameterDict GetNominals() const;
     ParameterDict GetFakeDataVals() const;
+    std::map<std::string,std::string> GetTexLabels() const;
 
     ParameterDict GetConstrMeans() const;
     ParameterDict GetConstrSigmas() const;

--- a/src/config/FitConfig.hh
+++ b/src/config/FitConfig.hh
@@ -34,10 +34,10 @@ namespace antinufit
     int GetHMCBurnIn() const;
     void SetHMCBurnIn(int);
 
-    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_);
-    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_,
+    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_);
+    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_,
                       double constrMean_, double constrSigma_);
-    void AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fakedata_,
+    void AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_,
                       double constrRatioMean_, double constrRatioSigma_,std::string constrRatioParName_);
 
     std::set<std::string> GetParamNames() const;
@@ -84,6 +84,7 @@ namespace antinufit
     ParameterDict fMaxima;
     ParameterDict fSigmas;
     ParameterDict fNbins;
+    std::map<std::string,std::string> fTexLabels;
     int fIterations;
     int fBurnIn;
     int fHMCIterations;

--- a/src/config/FitConfigLoader.cc
+++ b/src/config/FitConfigLoader.cc
@@ -111,6 +111,15 @@ namespace antinufit
       ConfigLoader::Load(name, "nbins", nbins);
       ConfigLoader::Load(name, "tex_label", texLabel);
 
+      // Remove "" if it surrounds the label string from the config
+      size_t start = 0;
+      size_t end = texLabel.size() - 1;
+      if (texLabel[start] == '"' || texLabel[start] == '\'')
+        start++;
+      if (end > start && (texLabel[end] == '"' || texLabel[end] == '\''))
+        end--;
+      texLabel = texLabel.substr(start, end - start + 1);
+
       try
       {
         ConfigLoader::Load(name, "nom", nom);
@@ -144,10 +153,10 @@ namespace antinufit
           ConfigLoader::Load(name, "constraint_ratioparname", constrRatioParName);
           ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, constrRatioMean, constrRatioSigma, constrRatioParName);
         }
-        catch(const ConfigFieldMissing &e_)
+        catch (const ConfigFieldMissing &e_)
         {
           ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel);
-        }   
+        }
       }
     }
 

--- a/src/config/FitConfigLoader.cc
+++ b/src/config/FitConfigLoader.cc
@@ -88,6 +88,7 @@ namespace antinufit
     double min;
     double max;
     double sig;
+    std::string texLabel;
     double constrMean;
     double constrSigma;
     double constrRatioMean;
@@ -108,6 +109,7 @@ namespace antinufit
       ConfigLoader::Load(name, "max", max);
       ConfigLoader::Load(name, "sig", sig);
       ConfigLoader::Load(name, "nbins", nbins);
+      ConfigLoader::Load(name, "tex_label", texLabel);
 
       try
       {
@@ -131,7 +133,7 @@ namespace antinufit
       {
         ConfigLoader::Load(name, "constraint_mean", constrMean);
         ConfigLoader::Load(name, "constraint_sigma", constrSigma);
-        ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, constrMean, constrSigma);
+        ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, constrMean, constrSigma);
       }
       catch (const ConfigFieldMissing &e_)
       {
@@ -140,11 +142,11 @@ namespace antinufit
           ConfigLoader::Load(name, "constraint_ratiomean", constrRatioMean);
           ConfigLoader::Load(name, "constraint_ratiosigma", constrRatioSigma);
           ConfigLoader::Load(name, "constraint_ratioparname", constrRatioParName);
-          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, constrRatioMean, constrRatioSigma, constrRatioParName);
+          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, constrRatioMean, constrRatioSigma, constrRatioParName);
         }
         catch(const ConfigFieldMissing &e_)
         {
-          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal);
+          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel);
         }   
       }
     }

--- a/util/plotFixedOscParams.C
+++ b/util/plotFixedOscParams.C
@@ -171,7 +171,7 @@ void plotFixedOscParams(const char *filename = "fit_results.root")
 
     // Draw the histograms
     TCanvas *c1 = new TCanvas("c1", "Params", 800, 600);
-    c1->SetBottomMargin(0.23);
+    c1->SetBottomMargin(0.18);
     gPad->SetFrameLineWidth(2);
     gStyle->SetOptStat(0);
     gPad->SetGrid(1);
@@ -189,10 +189,11 @@ void plotFixedOscParams(const char *filename = "fit_results.root")
 
     hConstr->GetYaxis()->SetRangeUser(0, 2);
     hConstr->GetYaxis()->SetTitle("Relative to Nominal");
-    //hConstr->GetXaxis()->SetLabelOffset(0.007);
-    hConstr->GetXaxis()->CenterLabels(true);
+    hConstr->GetYaxis()->SetTitleOffset(1.2);
+    hConstr->GetXaxis()->SetLabelOffset(0.007);
+    hConstr->GetXaxis()->SetTitle("Fit Parameters");
+    hConstr->GetXaxis()->SetTitleOffset(2.0);
     hConstr->SetTitle("");
-    hConstr->LabelsOption("v");
 
     hConstr->GetXaxis()->SetTitleFont(42);
     hConstr->GetYaxis()->SetTitleFont(42);

--- a/util/plotFixedOscParams.C
+++ b/util/plotFixedOscParams.C
@@ -8,15 +8,15 @@
 ///
 /// Script for plotting post fit parameter values and prefit
 /// constraints relative to nominal values for fixed oscillation fits.
-/// 
-/// The user inputs the root file made by makeFixedOscTree, and it 
+///
+/// The user inputs the root file made by makeFixedOscTree, and it
 /// first finds the entry with the lowest LLH. All the branches for
 /// this entry are read into a map, and the nominal values and
 /// constraints vectors are read in from the input file too. Those
-/// vectors are sorted into the order we want to plot (so this will 
+/// vectors are sorted into the order we want to plot (so this will
 /// need to be updated when parameters change).
 ///
-/// The plot is drawn and the canvas is saved as a root file and 
+/// The plot is drawn and the canvas is saved as a root file and
 /// pdf.
 ///
 /////////////////////////////////////////////////////////////////// */
@@ -29,6 +29,7 @@ void sortVectors(std::vector<std::string> *&namesVec, std::vector<std::string> *
     std::vector<double> *tempNomsVec = new std::vector<double>(namesVec->size(), 0.0);
     std::vector<double> *tempConstrMeansVec = new std::vector<double>(namesVec->size(), 0.0);
     std::vector<double> *tempConstrErrsVec = new std::vector<double>(namesVec->size(), 0.0);
+    std::vector<std::string> *tempLabelsVec = new std::vector<std::string>(namesVec->size(), "");
 
     // This is the order we want to plot them in (osc, signal, geo, alpha n, other bgs, systematics)
     std::vector<std::string> *tempNamesVec = new std::vector<std::string>{"deltam21",
@@ -45,21 +46,6 @@ void sortVectors(std::vector<std::string> *&namesVec, std::vector<std::string> *
                                                                           "birks_constant",
                                                                           "p_recoil_energy_scale"};
 
-    // Latex labels
-    std::vector<std::string> *tempLabelsVec = new std::vector<std::string>{"#Delta m^{2}_{21}",
-                                                                           "#theta_{12}",
-                                                                           "Reactor #bar{#nu}",
-                                                                           "Geo U",
-                                                                           "Geo Th",
-                                                                           "#alpha C Scatter",
-                                                                           "#alpha O excited",
-                                                                           "#alpha P Recoil",
-                                                                           "Sideband",
-                                                                           "Energy Scale",
-                                                                           "Energy Conv.",
-                                                                           "Birk's Constant",
-                                                                           "#alpha PR E. Scale"};
-
     // Now loop over the new vector (that's already in the correct order), and find the index of the same name
     // in the old vector, and set the noms and constraints to be the ones for that index
     for (int iTempName = 0; iTempName < tempNamesVec->size(); iTempName++)
@@ -71,6 +57,7 @@ void sortVectors(std::vector<std::string> *&namesVec, std::vector<std::string> *
                 tempNomsVec->at(iTempName) = nomsVec->at(iName);
                 tempConstrMeansVec->at(iTempName) = constrMeansVec->at(iName);
                 tempConstrErrsVec->at(iTempName) = constrErrsVec->at(iName);
+                tempLabelsVec->at(iTempName) = labelsVec->at(iName);
                 break;
             }
         }
@@ -152,6 +139,7 @@ void plotFixedOscParams(const char *filename = "fit_results.root")
     file->GetObject("param_asimov_values", nomVals);
     file->GetObject("constr_mean_values", constrMeans);
     file->GetObject("constr_sigma_values", constrErr);
+    file->GetObject("tex_labels", labelsVec);
 
     // Reorder vectors to the order we want to plot them
     sortVectors(paramNames, labelsVec, nomVals, constrMeans, constrErr);
@@ -183,6 +171,7 @@ void plotFixedOscParams(const char *filename = "fit_results.root")
 
     // Draw the histograms
     TCanvas *c1 = new TCanvas("c1", "Params", 800, 600);
+    c1->SetBottomMargin(0.23);
     gPad->SetFrameLineWidth(2);
     gStyle->SetOptStat(0);
     gPad->SetGrid(1);
@@ -200,8 +189,16 @@ void plotFixedOscParams(const char *filename = "fit_results.root")
 
     hConstr->GetYaxis()->SetRangeUser(0, 2);
     hConstr->GetYaxis()->SetTitle("Relative to Nominal");
-    hConstr->GetXaxis()->SetLabelOffset(0.007);
-    hConstr->SetTitle("Pre and Postfit Values Relative to Nominal");
+    //hConstr->GetXaxis()->SetLabelOffset(0.007);
+    hConstr->GetXaxis()->CenterLabels(true);
+    hConstr->SetTitle("");
+    hConstr->LabelsOption("v");
+
+    hConstr->GetXaxis()->SetTitleFont(42);
+    hConstr->GetYaxis()->SetTitleFont(42);
+    hConstr->GetXaxis()->SetLabelFont(42);
+    hConstr->GetYaxis()->SetLabelFont(42);
+    hConstr->SetTitleFont(42);
 
     hConstr->Draw("E1");
     hPostFit->Draw("E1same");
@@ -210,6 +207,7 @@ void plotFixedOscParams(const char *filename = "fit_results.root")
     t1->AddEntry(hConstr, "Prefit", "l");
     t1->AddEntry(hPostFit, "Postfit", "l");
     t1->SetLineWidth(2);
+    t1->SetTextFont(42);
     t1->Draw();
 
     // Save plot as image and rootfile


### PR DESCRIPTION
I move the tex labels from the event config/loader to the fit config/loader. 
These are then saved in the output root file from makeFixedOscTree, and used in the parameter and distribution plots

A check is added to fitconfigloader to remove "" from the start/end of label

I've also moved makeFixedOscTree from util to exec

I also save the reactor ratio in the output of makeFixedOscTree so that it can be used in the parameter plot