### PR TITLE
Correlated Constraints

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -101,13 +101,17 @@ The name of these tables should be the name of the fit parameter.
 - `constraint_sig`: Width of the prior constraint on the parameter
 - `constraint_ratiomean`: Mean of prior constraint on ratio of this parameter to another
 - `constraint_ratiosigma`: Width of prior constraint on ratio of this parameter to another
-- `constraint_ratioparname`: Name of other parameter the ratio constraint corresponds to. This must be another parameter defined and activated in this file. 
+- `constraint_ratioparname`: Name of other parameter the ratio constraint corresponds to. This must be another parameter defined and activated in this file.
+- `constraint_corr`: Correlation of this parameter to another
+- `constraint_corrparname`: Name of other parameter this parameter is correlated to. This must be another parameter defined and activated in this file. Both correlated parameters must have a `constraint_mean` and `constraint_sig` defined.
 - `fake_data_val`: Value to use to produce a fake dataset if `fake_data` is true in the Summary
 
 A note on HMCMC: There is currently the functionality to run some MCMC, followed by some HMCMC starting from the best fit points of the MCMC. However, this didn't give any improvement in results or efficiency over the straight MCMC. The functionality is preserved in case we ever want to use it in the future, but generally we'll just run MCMC, with a notional 1 step HMCMC ran to avoid problems with files not being created when they are expected to.
 It's likely in the future we'll just remove the functionality.
 
-A note on Ratio Constraints: There is currently functionality to have a constraint on the ratio between two parameters. This should be specified by defining the constraint for one parameter and setting `constraint_ratioparname` to the name of the other. Do not then define the constraint for the second parameter as well, else the constraint will be applied twice. It does not matter which of the two parameters you define it for. It is not currently possible to have a ratio constraint for a parameter with more than one other parameters. We could change this in the future if it is needed. 
+A note on Ratio Constraints: There is currently functionality to have a constraint on the ratio between two parameters. This should be specified by defining the constraint for one parameter and setting `constraint_ratioparname` to the name of the other. Do not then define the constraint for the second parameter as well, else the constraint will be applied twice. It does not matter which of the two parameters you define it for. It is not currently possible to have a ratio constraint for a parameter with more than one other parameters. We could change this in the future if it is needed.
+
+Similarly, for correlations, do not define the correlation for the second parameter as well or it will be applied twice. It does not matter which of the two parameters you define the correlation for. It is not currently possible for a parameter to have a correlation with more than one other parameter. This could also change in the future.
 
 <h4>PDF</h4>
 

--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -50,9 +50,9 @@ void fixedosc_fit(const std::string &fitConfigFile_,
   ParameterDict constrRatioMeans = fitConfig.GetConstrRatioMeans();
   ParameterDict constrRatioSigmas = fitConfig.GetConstrRatioSigmas();
   std::map<std::string, std::string> constrRatioParName = fitConfig.GetConstrRatioParName();
+  ParameterDict constrCorrs = fitConfig.GetConstrCorrs();
+  std::map<std::string, std::string> constrCorrParName = fitConfig.GetConstrCorrParName();
   ParameterDict fdValues = fitConfig.GetFakeDataVals();
-
-  std::cout << "save outputs " << saveOutputs << std::endl;
 
   std::string scaledDistDir = outDir + "/scaled_dists";
   std::string pdfDir = outDir + "/pdfs";
@@ -368,6 +368,9 @@ void fixedosc_fit(const std::string &fitConfigFile_,
     lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
   for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
     lh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+  for (ParameterDict::iterator it = constrCorrs.begin(); it != constrCorrs.end(); ++it)
+    lh.SetConstraint(it->first, constrMeans.at(it->first), constrSigmas.at(it->first), constrCorrParName.at(it->first),
+                     constrMeans.at(constrCorrParName.at(it->first)), constrSigmas.at(constrCorrParName.at(it->first)), it->second);
 
   // And finally bring it all together
   lh.RegisterFitComponents();

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -45,6 +45,8 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   ParameterDict constrRatioMeans = fitConfig.GetConstrRatioMeans();
   ParameterDict constrRatioSigmas = fitConfig.GetConstrRatioSigmas();
   std::map<std::string, std::string> constrRatioParName = fitConfig.GetConstrRatioParName();
+  ParameterDict constrCorrs = fitConfig.GetConstrCorrs();
+  std::map<std::string, std::string> constrCorrParName = fitConfig.GetConstrCorrParName();
   ParameterDict fdValues = fitConfig.GetFakeDataVals();
 
   // Create output directories
@@ -216,15 +218,15 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       dist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21_nom, theta12_nom, indexDistance, ratio);
 
       // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
-      
-      double noms_config = noms[it->first];  
+
+      double noms_config = noms[it->first];
       constrMeans[it->first] = constrMeans[it->first] * ratio;
       constrSigmas[it->first] = constrSigmas[it->first] * ratio;
       noms[it->first] = noms_config * ratio;
       mins[it->first] = mins[it->first] * ratio;
       maxs[it->first] = maxs[it->first] * ratio;
-      fdValues[it->first] = fdValues[it->first] *ratio;
-      
+      fdValues[it->first] = fdValues[it->first] * ratio;
+
       // Now loop over deltam points and make a new pdf for each
       for (int iDeltaM = 0; iDeltaM < npoints; iDeltaM++)
       {
@@ -424,6 +426,9 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
     lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
   for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
     lh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+  for (ParameterDict::iterator it = constrCorrs.begin(); it != constrCorrs.end(); ++it)
+    lh.SetConstraint(it->first, constrMeans.at(it->first), constrSigmas.at(it->first), constrCorrParName.at(it->first),
+                     constrMeans.at(constrCorrParName.at(it->first)), constrSigmas.at(constrCorrParName.at(it->first)), it->second);
   // And finally bring it all together
   lh.RegisterFitComponents();
 
@@ -547,6 +552,9 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       osclh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
     for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
       osclh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+    for (ParameterDict::iterator it = constrCorrs.begin(); it != constrCorrs.end(); ++it)
+      osclh.SetConstraint(it->first, constrMeans.at(it->first), constrSigmas.at(it->first), constrCorrParName.at(it->first),
+                          constrMeans.at(constrCorrParName.at(it->first)), constrSigmas.at(constrCorrParName.at(it->first)), it->second);
 
     if (iDeltaM % countwidth == 0)
       std::cout << iDeltaM << "/" << npoints << " (" << double(iDeltaM) / double(npoints) * 100 << "%)" << std::endl;
@@ -602,6 +610,9 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       osclh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
     for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
       osclh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+    for (ParameterDict::iterator it = constrCorrs.begin(); it != constrCorrs.end(); ++it)
+      osclh.SetConstraint(it->first, constrMeans.at(it->first), constrSigmas.at(it->first), constrCorrParName.at(it->first),
+                          constrMeans.at(constrCorrParName.at(it->first)), constrSigmas.at(constrCorrParName.at(it->first)), it->second);
 
     if (iTheta12 % countwidth == 0)
       std::cout << iTheta12 << "/" << npoints << " (" << double(iTheta12) / double(npoints) * 100 << "%)" << std::endl;

--- a/exec/llh_scan.cc
+++ b/exec/llh_scan.cc
@@ -45,6 +45,8 @@ void llh_scan(const std::string &fitConfigFile_,
   ParameterDict constrRatioMeans = fitConfig.GetConstrRatioMeans();
   ParameterDict constrRatioSigmas = fitConfig.GetConstrRatioSigmas();
   std::map<std::string, std::string> constrRatioParName = fitConfig.GetConstrRatioParName();
+  ParameterDict constrCorrs = fitConfig.GetConstrCorrs();
+  std::map<std::string, std::string> constrCorrParName = fitConfig.GetConstrCorrParName();
   ParameterDict fdValues = fitConfig.GetFakeDataVals();
 
   // Create output directories
@@ -302,6 +304,9 @@ void llh_scan(const std::string &fitConfigFile_,
     lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
   for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
     lh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+  for (ParameterDict::iterator it = constrCorrs.begin(); it != constrCorrs.end(); ++it)
+    lh.SetConstraint(it->first, constrMeans.at(it->first), constrSigmas.at(it->first), constrCorrParName.at(it->first),
+                     constrMeans.at(constrCorrParName.at(it->first)), constrSigmas.at(constrCorrParName.at(it->first)), it->second);
   // And finally bring it all together
   lh.RegisterFitComponents();
 

--- a/exec/mcmc.cc
+++ b/exec/mcmc.cc
@@ -48,6 +48,11 @@ void mcmc(const std::string &fitConfigFile_,
   ParameterDict noms = fitConfig.GetNominals();
   ParameterDict sigmas = fitConfig.GetSigmas();
   ParameterDict nbins = fitConfig.GetNBins();
+  ParameterDict constrRatioMeans = fitConfig.GetConstrRatioMeans();
+  ParameterDict constrRatioSigmas = fitConfig.GetConstrRatioSigmas();
+  std::map<std::string, std::string> constrRatioParName = fitConfig.GetConstrRatioParName();
+  ParameterDict constrCorrs = fitConfig.GetConstrCorrs();
+  std::map<std::string, std::string> constrCorrParName = fitConfig.GetConstrCorrParName();
   ParameterDict fdValues = fitConfig.GetFakeDataVals();
   double sigmaScale = fitConfig.GetSigmaScale();
 
@@ -308,6 +313,11 @@ void mcmc(const std::string &fitConfigFile_,
   // And constraints
   for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
     lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
+  for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
+    lh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+  for (ParameterDict::iterator it = constrCorrs.begin(); it != constrCorrs.end(); ++it)
+    lh.SetConstraint(it->first, constrMeans.at(it->first), constrSigmas.at(it->first), constrCorrParName.at(it->first),
+                     constrMeans.at(constrCorrParName.at(it->first)), constrSigmas.at(constrCorrParName.at(it->first)), it->second);
   // And finally bring it all together
   lh.RegisterFitComponents();
 

--- a/src/config/FitConfig.cc
+++ b/src/config/FitConfig.cc
@@ -213,6 +213,7 @@ namespace antinufit
   {
     return fConstrSigmas;
   }
+
   ParameterDict
   FitConfig::GetConstrRatioMeans() const
   {
@@ -224,10 +225,23 @@ namespace antinufit
   {
     return fConstrRatioSigmas;
   }
+
   std::map<std::string, std::string>
   FitConfig::GetConstrRatioParName() const
   {
     return fConstrRatioParName;
+  }
+
+  ParameterDict
+  FitConfig::GetConstrCorrs() const
+  {
+    return fConstrCorrs;
+  }
+
+  std::map<std::string, std::string>
+  FitConfig::GetConstrCorrParName() const
+  {
+    return fConstrCorrParName;
   }
 
   bool
@@ -278,4 +292,16 @@ namespace antinufit
     AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_, label_);
   }
 
+  void
+  FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_,
+                          std::string label_, double constrMean_, double constrSigma_, std::string constrCorrParName_, double constrCorr_)
+  {
+
+    fConstrMeans[name_] = constrMean_;
+    fConstrSigmas[name_] = constrSigma_;
+    fConstrCorrParName[name_] = constrCorrParName_;
+    fConstrCorrs[name_] = constrCorr_;
+
+    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_, label_);
+  }
 }

--- a/src/config/FitConfig.hh
+++ b/src/config/FitConfig.hh
@@ -16,14 +16,17 @@ namespace antinufit
     ParameterDict GetNBins() const;
     ParameterDict GetNominals() const;
     ParameterDict GetFakeDataVals() const;
-    std::map<std::string,std::string> GetTexLabels() const;
+    std::map<std::string, std::string> GetTexLabels() const;
 
     ParameterDict GetConstrMeans() const;
     ParameterDict GetConstrSigmas() const;
 
     ParameterDict GetConstrRatioMeans() const;
     ParameterDict GetConstrRatioSigmas() const;
-    std::map<std::string,std::string>   GetConstrRatioParName() const;
+    std::map<std::string, std::string> GetConstrRatioParName() const;
+
+    ParameterDict GetConstrCorrs() const;
+    std::map<std::string, std::string> GetConstrCorrParName() const;
 
     int GetIterations() const;
     void SetIterations(int);
@@ -38,8 +41,10 @@ namespace antinufit
     void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_);
     void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_,
                       double constrMean_, double constrSigma_);
+    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_,
+                      double constrMean_, double constrSigma_, std::string constrCorrParName_, double constrCorr_);
     void AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_,
-                      double constrRatioMean_, double constrRatioSigma_,std::string constrRatioParName_);
+                      double constrRatioMean_, double constrRatioSigma_, std::string constrRatioParName_);
 
     std::set<std::string> GetParamNames() const;
 
@@ -79,13 +84,14 @@ namespace antinufit
     ParameterDict fConstrSigmas;
     ParameterDict fConstrRatioMeans;
     ParameterDict fConstrRatioSigmas;
+    ParameterDict fConstrCorrs;
     ParameterDict fNominals;
     ParameterDict fFakeDataVals;
     ParameterDict fMinima;
     ParameterDict fMaxima;
     ParameterDict fSigmas;
     ParameterDict fNbins;
-    std::map<std::string,std::string> fTexLabels;
+    std::map<std::string, std::string> fTexLabels;
     int fIterations;
     int fBurnIn;
     int fHMCIterations;
@@ -99,7 +105,8 @@ namespace antinufit
     double fLivetime;
     bool fSaveOutputs;
     std::string fDatafile;
-    std::map<std::string,std::string> fConstrRatioParName;
+    std::map<std::string, std::string> fConstrRatioParName;
+    std::map<std::string, std::string> fConstrCorrParName;
   };
 }
 #endif

--- a/src/config/FitConfigLoader.cc
+++ b/src/config/FitConfigLoader.cc
@@ -94,6 +94,8 @@ namespace antinufit
     double constrRatioMean;
     double constrRatioSigma;
     std::string constrRatioParName;
+    double constrCorr;
+    std::string constrCorrParName;
     int nbins;
 
     if (std::find(toLoad.begin(), toLoad.end(), "all") != toLoad.end())
@@ -142,7 +144,16 @@ namespace antinufit
       {
         ConfigLoader::Load(name, "constraint_mean", constrMean);
         ConfigLoader::Load(name, "constraint_sigma", constrSigma);
-        ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, constrMean, constrSigma);
+        try
+        {
+          ConfigLoader::Load(name, "constraint_corr", constrCorr);
+          ConfigLoader::Load(name, "constraint_corrparname", constrCorrParName);
+          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, constrMean, constrSigma, constrCorrParName, constrCorr);
+        }
+        catch (const ConfigFieldMissing &e_)
+        {
+          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, constrMean, constrSigma);
+        }
       }
       catch (const ConfigFieldMissing &e_)
       {


### PR DESCRIPTION
This allows us to make use of the correlated constraints in the teststat if we want to. It works similarly to the ratio constraints, for one parameter you add a correlation and parameter name

The shortcoming is you can only currently input one correlation per parameter through the fit config. We will one day just give the fit a matrix of parameters to improve this (but it's not needed for now and would need big oxo changes)