### PR TITLE
Apply Systs to Individual Scaled Postfit PDFs that get Saved as Histos

### DIFF
--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -448,23 +448,26 @@ void fixedosc_fit(const std::string &fitConfigFile_,
       {
         std::string name = pdfs.at(i).GetName();
         pdfs[i].Normalise();
+        // Apply bestfit systematic variables
+        for (std::map<std::string, Systematic *>::iterator systIt = systMap.begin(); systIt != systMap.end(); ++systIt)
+        {
+          // If group is "", we apply to all groups
+          if (systGroup[systIt->first] == "" || std::find(pdfGroups.back().begin(), pdfGroups.back().end(), systGroup[systIt->first]) != pdfGroups.back().end())
+          {
+            std::set<std::string> systParamNames = systMap[systIt->first]->GetParameterNames();
+            for (auto itSystParam = systParamNames.begin(); itSystParam != systParamNames.end(); ++itSystParam)
+            {
+              systMap[systIt->first]->SetParameter(*itSystParam, bestFit[*itSystParam]);
+            }
+            pdfs[i] = systIt->second->operator()(pdfs[i]);
+          }
+        }
         pdfs[i].Scale(bestFit[name]);
         IO::SaveHistogram(pdfs[i].GetHistogram(), scaledDistDir + "/" + name + ".root");
         // Sum all scaled distributions to get full postfit "dataset"
         postfitDist.Add(pdfs[i]);
       }
 
-      for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)
-      {
-        double distInt = postfitDist.Integral();
-        std::set<std::string> systParamNames = systMap[it->first]->GetParameterNames();
-        for (auto itSystParam = systParamNames.begin(); itSystParam != systParamNames.end(); ++itSystParam)
-        {
-          systMap[it->first]->SetParameter(*itSystParam, bestFit[*itSystParam]);
-        }
-        postfitDist = systMap[it->first]->operator()(postfitDist);
-        postfitDist.Scale(distInt);
-      }
       IO::SaveHistogram(postfitDist.GetHistogram(), scaledDistDir + "/postfitdist.root");
     }
     else
@@ -474,6 +477,20 @@ void fixedosc_fit(const std::string &fitConfigFile_,
       {
         std::string name = pdfs.at(i).GetName();
         pdfs[i].Normalise();
+        // Apply bestfit systematic variables
+        for (std::map<std::string, Systematic *>::iterator systIt = systMap.begin(); systIt != systMap.end(); ++systIt)
+        {
+          // If group is "", we apply to all groups
+          if (systGroup[systIt->first] == "" || std::find(pdfGroups.back().begin(), pdfGroups.back().end(), systGroup[systIt->first]) != pdfGroups.back().end())
+          {
+            std::set<std::string> systParamNames = systMap[systIt->first]->GetParameterNames();
+            for (auto itSystParam = systParamNames.begin(); itSystParam != systParamNames.end(); ++itSystParam)
+            {
+              systMap[systIt->first]->SetParameter(*itSystParam, bestFit[*itSystParam]);
+            }
+            pdfs[i] = systIt->second->operator()(pdfs[i]);
+          }
+        }
         pdfs[i].Scale(bestFit[name]);
 
         std::vector<std::string> keepObs;
@@ -484,19 +501,7 @@ void fixedosc_fit(const std::string &fitConfigFile_,
         postfitDist.Add(pdfs[i]);
       }
 
-      for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)
-      {
-        double distInt = postfitDist.Integral();
-        std::set<std::string> systParamNames = systMap[it->first]->GetParameterNames();
-        for (auto itSystParam = systParamNames.begin(); itSystParam != systParamNames.end(); ++itSystParam)
-        {
-          systMap[it->first]->SetParameter(*itSystParam, bestFit[*itSystParam]);
-        }
-        postfitDist = systMap[it->first]->operator()(postfitDist);
-        postfitDist.Scale(distInt);
-
-        IO::SaveHistogram(postfitDist.GetHistogram(), scaledDistDir + "/postfitdist.root");
-      }
+      IO::SaveHistogram(postfitDist.GetHistogram(), scaledDistDir + "/postfitdist.root");
     }
 
     // And also save the data


### PR DESCRIPTION
The old method was:

- Loop over PDFs:
    - scale to best fit norm
    - add to postfit sum of all pdfs
    - save as histogram
- Loop over systs:
    - apply syst to sum of all scaled pdfs
- Save sum of all scaled pdfs as histogram


Now the method is:

- Loop over PDFs:
    - Loop over systs:
        - apply syst to pdf
    - scale to best fit norm
    - add to postfit sum of all pdfs
    - save as histogram
- Save sum of all scaled pdfs as histogram