### PR TITLE
Plot to Compare Fit Params

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -311,9 +311,15 @@ In this script Latex labels are made for each PDF (currently reactor IBDs, Geo U
 
 <h4>plotFixedOscParams</h4>
 
-This script loops over all entries in the output `TTree` from `makeFixedOscTree`, and finds the fit with the minimum best LLH. It then plots each parameter in that entry, relative to it's nominal value. Any prefit constraints are also plotted, relative to nominal values. A canvas is saved in both a `.root` and `.pdf` file, in the top level output directory of the set of fits. You can run it with:
+This script loops over all entries in the output `TTree` from `makeFixedOscTree`, and finds the fit with the minimum best LLH. It then plots each parameter in that entry, relative to it's nominal value. Any prefit constraints are also plotted, relative to nominal values. A canvas is saved in both a `.root` and `.pdf` file, in the top level output directory of the set of fits. The constraint, nominal, and postfit histograms are also saved in the root file. You can run it with:
 
 > root -l 'util/plotFixedOscParams.C("/path/to/makeFixedOscTree/output")'
+
+<h4>compareFixedOscParams</h4>
+
+This script opens the outputted root file from `plotFixedOscParams` for two different fits, and plots the postfit parameters for each and the prefit nominals and constraints from the first. The user also inputs labels for each fit to be printed into the legend, along with the name (without file type suffix) of the outputted files. You can run it with:
+
+> root -l 'util/compareFixedOscParams.C("/path/to/fit1/params.root", "fit 1 label", "/path/to/fit2/params.root", "fit 2 label", "/path/to/output/file")'
 
 <h3>MCMC</h3>
 

--- a/util/compareFixedOscParams.C
+++ b/util/compareFixedOscParams.C
@@ -1,0 +1,112 @@
+#include <TFile.h>
+#include <TTree.h>
+#include <TH2D.h>
+#include <TCanvas.h>
+#include <TStyle.h>
+
+/* ///////////////////////////////////////////////////////////////////
+///
+/// Script for comparing post fit parameter values and prefit
+/// constraints relative to nominal values for two different sets of
+/// fixed oscillation fits.
+///
+/// The user inputs the root files made by plotFixedOscParams for
+/// both fits, along with labels to be printed in the legend for
+/// each, and an output filename.
+///
+/// The nominal and constraint histograms are got from the first fit
+/// params file, and postfit histograms are taken from both fit
+/// param files.
+///
+/// The plot is drawn and the canvas is saved as a pdf and a root
+/// file, along with each of the histograms.
+///
+/////////////////////////////////////////////////////////////////// */
+
+void compareFixedOscParams(std::string filename1, std::string label1, std::string filename2, std::string label2, std::string outfilename)
+{
+
+    // Open the ROOT file
+    TFile *file1 = TFile::Open(filename1.c_str(), "READ");
+    if (!file1 || file1->IsZombie())
+    {
+        std::cerr << "Error: Could not open file " << filename1 << std::endl;
+        return;
+    }
+
+    TFile *file2 = TFile::Open(filename2.c_str(), "READ");
+    if (!file2 || file2->IsZombie())
+    {
+        std::cerr << "Error: Could not open file " << filename2 << std::endl;
+        return;
+    }
+
+    // Get the histos
+    TH1D *hNom1 = (TH1D *)file1->Get("nominal");
+    hNom1->SetName("nominal1");
+    hNom1->SetTitle("nominal1");
+    TH1D *hConstr1 = (TH1D *)file1->Get("constraints");
+    hConstr1->SetName("constraints1");
+    hConstr1->SetTitle("constraints1");
+    TH1D *hPostFit1 = (TH1D *)file1->Get("postfit");
+    hPostFit1->SetName("postfit1");
+    hPostFit1->SetTitle("postfit1");
+
+    TH1D *hPostFit2 = (TH1D *)file2->Get("postfit");
+    hPostFit2->SetName("postfit2");
+    hPostFit2->SetTitle("postfit2");
+
+    // Draw the histograms
+    TCanvas *c1 = new TCanvas("c1", "Params", 800, 600);
+    c1->SetBottomMargin(0.18);
+    gPad->SetFrameLineWidth(2);
+    gStyle->SetOptStat(0);
+    gPad->SetGrid(1);
+
+    hNom1->SetLineColor(kGreen);
+    hNom1->SetLineWidth(2);
+    hConstr1->SetLineColor(kBlue);
+    hConstr1->SetLineWidth(2);
+    hPostFit1->SetLineColor(kRed);
+    hPostFit1->SetLineWidth(2);
+    hPostFit2->SetLineColor(kBlack);
+    hPostFit2->SetLineWidth(2);
+    hPostFit2->SetLineStyle(2);
+    // TODO: We'll want these when we have proper error bars
+    // hPostFit1->SetMarkerStyle(2);
+    // hPostFit1->SetMarkerSize(4);
+    // hPostFit1->SetMarkerColor(kRed);
+    // hPostFit2->SetMarkerStyle(2);
+    // hPostFit2->SetMarkerSize(4);
+    // hPostFit2->SetMarkerColor(kBlack);
+
+    hConstr1->GetYaxis()->SetRangeUser(0, 2);
+    hConstr1->GetYaxis()->SetTitle("Relative to Nominal");
+    hConstr1->GetYaxis()->SetTitleOffset(1.2);
+    hConstr1->GetXaxis()->SetLabelOffset(0.007);
+    hConstr1->GetXaxis()->SetTitle("Fit Parameters");
+    hConstr1->GetXaxis()->SetTitleOffset(2.0);
+    hConstr1->SetTitle("");
+
+    hConstr1->GetXaxis()->SetTitleFont(42);
+    hConstr1->GetYaxis()->SetTitleFont(42);
+    hConstr1->GetXaxis()->SetLabelFont(42);
+    hConstr1->GetYaxis()->SetLabelFont(42);
+    hConstr1->SetTitleFont(42);
+
+    hConstr1->Draw("E1");
+    hPostFit1->Draw("E1same");
+    hPostFit2->Draw("E1same");
+
+    TLegend *t1 = new TLegend(0.65, 0.7, 0.88, 0.88);
+    t1->AddEntry(hConstr1, "Prefit", "l");
+    t1->AddEntry(hPostFit1, ("Postfit " + label1).c_str(), "l");
+    t1->AddEntry(hPostFit2, ("Postfit " + label2).c_str(), "l");
+    t1->SetLineWidth(2);
+    t1->SetTextFont(42);
+    t1->Draw();
+
+    // Save plot as image and rootfile
+    c1->SaveAs((outfilename + ".pdf").c_str());
+    c1->SaveAs((outfilename + ".root").c_str());
+}

--- a/util/plotFixedOscParams.C
+++ b/util/plotFixedOscParams.C
@@ -16,8 +16,8 @@
 /// vectors are sorted into the order we want to plot (so this will
 /// need to be updated when parameters change).
 ///
-/// The plot is drawn and the canvas is saved as a root file and
-/// pdf.
+/// The plot is drawn and the canvas is saved as pdf and a root file,
+/// along with each of the histograms.
 ///
 /////////////////////////////////////////////////////////////////// */
 
@@ -216,5 +216,10 @@ void plotFixedOscParams(const char *filename = "fit_results.root")
     pathObj.replace_filename("params.pdf");
     c1->SaveAs(pathObj.string().c_str());
     pathObj.replace_filename("params.root");
-    c1->SaveAs(pathObj.string().c_str());
+    TFile* outfile = new TFile(pathObj.string().c_str(), "RECREATE");
+    outfile->cd();
+    hNom->Write("nominal");
+    hConstr->Write("constraints");
+    hPostFit->Write("postfit");
+    c1->Write("c1");
 }


### PR DESCRIPTION
Adds a script to compare fit parameters for two fits. First needed an edit to plotFixedOscParams to save the histograms as well as the original canvas.

User inputs output from plotFixedOscParams from two fits, along with legend labels for each and an output filename.

It uses the nominal and constraints histogram from the first fit, and the postfit parameters histograms from each fit, and plots them all together (relative to nominal). If we get in a situation where we need to compare fits with different nominals/constraints we might want to modify this or have a separate script, as we'd have to be careful what would be the denominator for the y axis