### PR TITLE
Print Parameters at Start of Fit

### DIFF
--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -158,6 +158,8 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       paramIt++;
   }
 
+  PrintParams(noms, mins, maxs, constrMeans, constrSigmas, constrRatioMeans, constrRatioSigmas, constrRatioParName, constrCorrs, constrCorrParName);
+
   // Create the individual PDFs and Asimov components
   std::vector<BinnedED> pdfs;
   std::vector<int> genRates;
@@ -421,14 +423,24 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
     lh.AddSystematic(it->second, systGroup[it->first]);
   // Add our pdfs
   lh.AddPdfs(pdfs, pdfGroups, genRates, norm_fitting_statuses);
+
   // And constraints
-  for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
-    lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
-  for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
-    lh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+  std::vector<std::string> corrPairs;
   for (ParameterDict::iterator it = constrCorrs.begin(); it != constrCorrs.end(); ++it)
+  {
     lh.SetConstraint(it->first, constrMeans.at(it->first), constrSigmas.at(it->first), constrCorrParName.at(it->first),
                      constrMeans.at(constrCorrParName.at(it->first)), constrSigmas.at(constrCorrParName.at(it->first)), it->second);
+    corrPairs.push_back(constrCorrParName.at(it->first));
+  }
+  for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
+  {
+    // Only add single parameter constraint if correlation hasn't already been applied
+    if (!constrCorrs[it->first] && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
+      lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
+  }
+  for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
+    lh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+
   // And finally bring it all together
   lh.RegisterFitComponents();
 
@@ -547,14 +559,19 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
     }
     osclh.AddPdfs(pdfvec, pdfGroups, genRates, norm_fitting_statuses);
 
-    // And set any constraints
-    for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
-      osclh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
-    for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
-      osclh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+    // And constraints
+    std::vector<std::string> corrPairs;
     for (ParameterDict::iterator it = constrCorrs.begin(); it != constrCorrs.end(); ++it)
       osclh.SetConstraint(it->first, constrMeans.at(it->first), constrSigmas.at(it->first), constrCorrParName.at(it->first),
                           constrMeans.at(constrCorrParName.at(it->first)), constrSigmas.at(constrCorrParName.at(it->first)), it->second);
+    for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
+    {
+      // Only add single parameter constraint if correlation hasn't already been applied
+      if (!constrCorrs[it->first] && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
+        osclh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
+    }
+    for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
+      osclh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
 
     if (iDeltaM % countwidth == 0)
       std::cout << iDeltaM << "/" << npoints << " (" << double(iDeltaM) / double(npoints) * 100 << "%)" << std::endl;
@@ -606,14 +623,18 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
     osclh.AddPdfs(pdfvec, pdfGroups, genRates, norm_fitting_statuses);
 
     // And set any constraints
-    for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
-      osclh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
-    for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
-      osclh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+    std::vector<std::string> corrPairs;
     for (ParameterDict::iterator it = constrCorrs.begin(); it != constrCorrs.end(); ++it)
       osclh.SetConstraint(it->first, constrMeans.at(it->first), constrSigmas.at(it->first), constrCorrParName.at(it->first),
                           constrMeans.at(constrCorrParName.at(it->first)), constrSigmas.at(constrCorrParName.at(it->first)), it->second);
-
+    for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
+    {
+      // Only add single parameter constraint if correlation hasn't already been applied
+      if (!constrCorrs[it->first] && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
+        osclh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
+    }
+    for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
+      osclh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
     if (iTheta12 % countwidth == 0)
       std::cout << iTheta12 << "/" << npoints << " (" << double(iTheta12) / double(npoints) * 100 << "%)" << std::endl;
 

--- a/exec/mcmc.cc
+++ b/exec/mcmc.cc
@@ -168,6 +168,8 @@ void mcmc(const std::string &fitConfigFile_,
       it++;
   }
 
+  PrintParams(noms, mins, maxs, constrMeans, constrSigmas, constrRatioMeans, constrRatioSigmas, constrRatioParName, constrCorrs, constrCorrParName);
+
   // Create the individual PDFs and Asimov components (could these be maps not vectors?)
   std::vector<BinnedED> pdfs;
   std::vector<int> genRates;
@@ -308,14 +310,24 @@ void mcmc(const std::string &fitConfigFile_,
     lh.AddSystematic(it->second, systGroup[it->first]);
   // Add our pdfs
   lh.AddPdfs(pdfs, pdfGroups, genRates, norm_fitting_statuses);
+
   // And constraints
-  for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
-    lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
-  for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
-    lh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+  std::vector<std::string> corrPairs;
   for (ParameterDict::iterator it = constrCorrs.begin(); it != constrCorrs.end(); ++it)
+  {
     lh.SetConstraint(it->first, constrMeans.at(it->first), constrSigmas.at(it->first), constrCorrParName.at(it->first),
                      constrMeans.at(constrCorrParName.at(it->first)), constrSigmas.at(constrCorrParName.at(it->first)), it->second);
+    corrPairs.push_back(constrCorrParName.at(it->first));
+  }
+  for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
+  {
+    // Only add single parameter constraint if correlation hasn't already been applied
+    if (!constrCorrs[it->first] && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
+      lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
+  }
+  for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
+    lh.SetConstraint(it->first, constrRatioParName.at(it->first), it->second, constrRatioSigmas.at(it->first));
+
   // And finally bring it all together
   lh.RegisterFitComponents();
 

--- a/src/util/Utilities.cc
+++ b/src/util/Utilities.cc
@@ -151,4 +151,143 @@ namespace antinufit
         }
         return tokens;
     }
+
+    void PrintParams(ParameterDict mins, ParameterDict maxs, ParameterDict noms, ParameterDict constrMeans, ParameterDict constrSigmas,
+                     ParameterDict constrRatioMeans, ParameterDict constrRatioSigmas, std::map<std::string, std::string> constrRatioParName,
+                     ParameterDict constrCorrs, std::map<std::string, std::string> constrCorrParName)
+    {
+
+        std::vector<std::string> *tempNamesVec = new std::vector<std::string>{"deltam21",
+                                                                              "theta12",
+                                                                              "reactor_nubar",
+                                                                              "geonu_U",
+                                                                              "geonu_Th",
+                                                                              "alphan_CScatter",
+                                                                              "alphan_OExcited",
+                                                                              "alphan_PRecoil",
+                                                                              "sideband",
+                                                                              "energy_scale",
+                                                                              "energy_conv",
+                                                                              "birks_constant",
+                                                                              "p_recoil_energy_scale"};
+
+        for (std::map<std::string, double>::iterator it = noms.begin(); it != noms.end(); it++)
+        {
+            if (std::find(tempNamesVec->begin(), tempNamesVec->end(), it->first) != tempNamesVec->end())
+                continue;
+            tempNamesVec->push_back(it->first);
+        }
+
+        std::cout << std::endl;
+        std::cout << "************** Fit Parameters **************" << std::endl;
+        std::cout << " -------------------------------------------------------------------------------------------------------------------------" << std::endl;
+        std::cout << "| ";
+        std::cout << std::left << std::setw(25) << "Name";
+        std::cout << "| ";
+        std::cout << std::left << std::setw(15) << "Nominal";
+        std::cout << "| ";
+        std::cout << std::left << std::setw(15) << "Minimum";
+        std::cout << "| ";
+        std::cout << std::left << std::setw(15) << "Maximum";
+        std::cout << "| ";
+        std::cout << std::left << std::setw(20) << "Constraint Mean";
+        std::cout << "| ";
+        std::cout << std::left << std::setw(20) << "Constraint Sigma";
+        std::cout << "| " << std::endl;
+        std::cout << " =========================================================================================================================" << std::endl;
+        for (int iParam = 0; iParam < tempNamesVec->size(); iParam++)
+        {
+
+            if (!noms[tempNamesVec->at(iParam)])
+                continue;
+
+            std::cout << "| ";
+            std::cout << std::left << std::setw(25) << tempNamesVec->at(iParam);
+            std::cout << "| ";
+            std::cout << std::left << std::setw(15) << noms[tempNamesVec->at(iParam)];
+            std::cout << "| ";
+            std::cout << std::left << std::setw(15) << mins[tempNamesVec->at(iParam)];
+            std::cout << "| ";
+            std::cout << std::left << std::setw(15) << maxs[tempNamesVec->at(iParam)];
+            std::cout << "| ";
+            if (constrMeans[tempNamesVec->at(iParam)])
+            {
+                std::cout << std::left << std::setw(20) << constrMeans[tempNamesVec->at(iParam)];
+                std::cout << "| ";
+                std::cout << std::left << std::setw(20) << constrSigmas[tempNamesVec->at(iParam)];
+                std::cout << "| ";
+            }
+            else
+            {
+                std::cout << std::left << std::setw(20) << "" << "| ";
+                std::cout << std::left << std::setw(20) << "" << "| ";
+            }
+            std::cout << std::endl;
+        }
+
+        std::cout << " -------------------------------------------------------------------------------------------------------------------------" << std::endl;
+        if (constrRatioMeans.size() > 0)
+        {
+            std::cout << std::endl;
+            std::cout << "************** Ratio Constraints **************" << std::endl;
+            std::cout << " -------------------------------------------------------------------------------------------------" << std::endl;
+            std::cout << "| ";
+            std::cout << std::left << std::setw(25) << "Parameter";
+            std::cout << "| ";
+            std::cout << std::left << std::setw(25) << "Parameter";
+            std::cout << "| ";
+            std::cout << std::left << std::setw(20) << "Constraint Mean";
+            std::cout << "| ";
+            std::cout << std::left << std::setw(20) << "Constraint Sigma";
+            std::cout << "| " << std::endl;
+            std::cout << " =================================================================================================" << std::endl;
+
+            for (std::map<std::string, double>::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); it++)
+            {
+                std::cout << "| ";
+                std::cout << std::left << std::setw(25) << it->first;
+                std::cout << "| ";
+                std::cout << std::left << std::setw(25) << constrRatioParName[it->first];
+                std::cout << "| ";
+                std::cout << std::left << std::setw(20) << constrRatioMeans[it->first];
+                std::cout << "| ";
+                std::cout << std::left << std::setw(20) << constrRatioSigmas[it->first];
+                std::cout << "| ";
+            }
+            std::cout << std::endl;
+            std::cout << " -------------------------------------------------------------------------------------------------" << std::endl;
+        }
+
+        if (constrCorrs.size() > 0)
+        {
+            std::cout << std::endl;
+            std::cout << "************** Correlations **************" << std::endl;
+            std::cout << " ---------------------------------------------------------------------------" << std::endl;
+            std::cout << "| ";
+            std::cout << std::left << std::setw(25) << "Parameter";
+            std::cout << "| ";
+            std::cout << std::left << std::setw(25) << "Parameter";
+            std::cout << "| ";
+            std::cout << std::left << std::setw(20) << "Correlation";
+            std::cout << "| ";
+            std::cout << std::endl;
+            std::cout << " ===========================================================================" << std::endl;
+
+            for (std::map<std::string, double>::iterator it = constrCorrs.begin(); it != constrCorrs.end(); it++)
+            {
+                std::cout << "| ";
+                std::cout << std::left << std::setw(25) << it->first;
+                std::cout << "| ";
+                std::cout << std::left << std::setw(25) << constrCorrParName[it->first];
+                std::cout << "| ";
+                std::cout << std::left << std::setw(20) << constrCorrs[it->first];
+                std::cout << "| ";
+            }
+            std::cout << std::endl;
+            std::cout << " ---------------------------------------------------------------------------" << std::endl;
+        }
+
+        std::cout << std::endl;
+        return;
+    }
 }

--- a/src/util/Utilities.hh
+++ b/src/util/Utilities.hh
@@ -7,6 +7,9 @@
 #include <nlohmann/json.hpp>
 #include <iostream>
 
+// OXO headers
+#include <ParameterDict.h>
+
 // ROOT headers
 #include <TVector3.h>
 
@@ -20,5 +23,7 @@ namespace antinufit
   std::vector<double> LinSpace(double, double, size_t);
   std::pair<size_t, size_t> GetLowerUpperIndices(const std::vector<double>, double);
   std::vector<std::string> SplitString(const std::string &, char);
+  void PrintParams(ParameterDict, ParameterDict, ParameterDict, ParameterDict, ParameterDict, ParameterDict, ParameterDict,
+                   std::map<std::string, std::string>, ParameterDict, std::map<std::string, std::string>);
 }
 #endif


### PR DESCRIPTION
Prints a nice table so you can see exactly what's being fit

also don't add single constraints if the parameter is part of a correlation. We don't run with any correlations yet so this wasn't a problem but it would crash if you tried. This came up when I tested how it makes a table for correlated constraints