### PR TITLE
Add Memory Option to Submission Scripts

### DIFF
--- a/util/submitCondor.py
+++ b/util/submitCondor.py
@@ -16,7 +16,7 @@ def check_dir(dname):
     return dname
 
 
-def pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config, event_config, pdf_config, syst_config, osc_config, walltime, sleep_time = 1, priority = 5):
+def pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config, event_config, pdf_config, syst_config, osc_config, walltime, mem, sleep_time = 1, priority = 5):
     '''
     submit a job to condor, write a sh file to source environment and execute command
     then write a submit file to be run by condor_submit
@@ -106,6 +106,7 @@ def pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config,
                      "priority                 = " + str(priority) + "\n" + \
                      "getenv                   = " + str(getenv) + "\n" + \
                      "allowed_execute_duration = " + str(walltime) + " \n" + \
+                     "request_memory           = " + str(mem) + " \n" + \
                      "queue "+str(n_rep)+"\n"
 
     # Check and create output path
@@ -135,6 +136,7 @@ if __name__ == "__main__":
     parser.add_argument('-o', "--osc_cfg", type=str, default="", help='osc grid config path')
     parser.add_argument("-n", "--num_jobs", type=int, default=1, help="how many identical jobs would you like to run?")
     parser.add_argument("-w", "--wall_time", type=int, default=86400, help="what's the maximum runtime (in seconds, default 1 day)?")
+    parser.add_argument("-m", "--mem", type=float, default=300, help="what's the maximum memory (in MB, default 300 MB)?")
     parser.add_argument("-j", "--job_name", type=str, default="", help='job name')
     args = parser.parse_args()
 
@@ -150,6 +152,7 @@ if __name__ == "__main__":
     syst_config = args.syst_cfg
     osc_config = args.osc_cfg
     walltime = args.wall_time
+    mem = args.mem
     job_name = args.job_name
     if fit_config != "":
         fit_config = run_dir + "/" + args.fit_cfg
@@ -193,7 +196,7 @@ if __name__ == "__main__":
             submit_dir = check_dir("{0}/submit/".format(out_dir))
             output_dir = check_dir("{0}/output/".format(out_dir))
 
-            pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config, event_config, pdf_config, syst_config, osc_config, walltime, sleep_time = 1, priority = 5)
+            pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config, event_config, pdf_config, syst_config, osc_config, walltime, mem, sleep_time = 1, priority = 5)
 
     else:
         # Otherwise do N jobs
@@ -207,4 +210,4 @@ if __name__ == "__main__":
             submit_dir = check_dir("{0}/submit/".format(out_dir))
             output_dir = check_dir("{0}/output/".format(out_dir))
 
-            pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config, event_config, pdf_config, syst_config, osc_config, walltime, sleep_time = 1, priority = 5)
+            pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config, event_config, pdf_config, syst_config, osc_config, walltime, mem, sleep_time = 1, priority = 5)

--- a/util/submitFixedOscJobs.py
+++ b/util/submitFixedOscJobs.py
@@ -68,7 +68,7 @@ def read_osccfg(filename):
     return numvalsdeltam, numvalstheta
 
 
-def pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config, event_config, pdf_config, syst_config, osc_config, walltime, theta, sleep_time = 1, priority = 5):
+def pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config, event_config, pdf_config, syst_config, osc_config, walltime, mem, theta, sleep_time = 1, priority = 5):
     '''
     submit a job to condor, write a sh file to source environment and execute command
     then write a submit file to be run by condor_submit
@@ -188,6 +188,7 @@ def pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config,
                      "priority                 = " + str(priority) + "\n" + \
                      "getenv                   = " + str(getenv) + "\n" + \
                      "allowed_execute_duration = " + str(walltime) + " \n" + \
+                     "request_memory           = " + str(mem) + " \n" + \
                      "queue "+str(n_rep)+"\n"
 
     # Check and create output path
@@ -216,6 +217,7 @@ if __name__ == "__main__":
     parser.add_argument('-s', "--syst_cfg", type=str, default="", help='syst config path')
     parser.add_argument('-o', "--osc_cfg", type=str, default="", help='osc grid config path')
     parser.add_argument("-w", "--wall_time", type=int, default=86400, help="what's the maximum runtime (in seconds, default 1 day)?")
+    parser.add_argument("-m", "--mem", type=float, default=300, help="what's the maximum memory (in MB, default 300 MB)?")
     parser.add_argument("-j", "--job_name", type=str, default="", help='job name')
     args = parser.parse_args()
 
@@ -231,6 +233,7 @@ if __name__ == "__main__":
     syst_config = args.syst_cfg
     osc_config = args.osc_cfg
     walltime = args.wall_time
+    mem = args.mem
     job_name = args.job_name
 
     if fit_config != "":
@@ -264,4 +267,4 @@ if __name__ == "__main__":
         submit_dir = check_dir("{0}/submit/".format(out_dir))
         output_dir = check_dir("{0}/output/".format(out_dir))
 
-        pycondor_submit(batch_name, exec_name, out_dir, run_dir, env_file, fit_config, event_config, pdf_config, syst_config, osc_config, walltime, theta, sleep_time = 1, priority = 5)
+        pycondor_submit(batch_name, exec_name, out_dir, run_dir, env_file, fit_config, event_config, pdf_config, syst_config, osc_config, walltime, mem, theta, sleep_time = 1, priority = 5)


### PR DESCRIPTION
With the -m flag, you can set the maximum memory you want to request for your fits

The default on condor is 2GB but our fixed osc fit jobs use like 200MB. So I set the default in our submission scripts to request 400 MB, and with -m you can change that. 

This should mean we don't lose our queue priorities as quickly!