### PR TITLE
Construct Systs

### DIFF
--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -251,6 +251,7 @@ void fixedosc_fit(const std::string &fitConfigFile_,
         {
           systMap[systIt->first]->SetParameter(*itSystParam, fdValues[*itSystParam]);
         }
+        systIt->second->Construct();
         fakeDataDist = systIt->second->operator()(fakeDataDist, &norm);
       }
     }
@@ -488,6 +489,7 @@ void fixedosc_fit(const std::string &fitConfigFile_,
               systMap[systIt->first]->SetParameter(*itSystParam, bestFit[*itSystParam]);
             }
             double norm;
+            systIt->second->Construct();
             pdfs[i] = systIt->second->operator()(pdfs[i], &norm);
           }
         }
@@ -518,6 +520,7 @@ void fixedosc_fit(const std::string &fitConfigFile_,
               systMap[systIt->first]->SetParameter(*itSystParam, bestFit[*itSystParam]);
             }
             double norm;
+            systIt->second->Construct();
             pdfs[i] = systIt->second->operator()(pdfs[i], &norm);
           }
         }

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -316,6 +316,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
         {
           systMap[systIt->first]->SetParameter(*itSystParam, fdValues[*itSystParam]);
         }
+        systIt->second->Construct();
         fakeDataDist = systIt->second->operator()(fakeDataDist, &norm);
       }
     }

--- a/exec/llh_scan.cc
+++ b/exec/llh_scan.cc
@@ -218,6 +218,7 @@ void llh_scan(const std::string &fitConfigFile_,
         {
           systMap[systIt->first]->SetParameter(*itSystParam, fdValues[*itSystParam]);
         }
+        systIt->second->Construct();
         fakeDataDist = systIt->second->operator()(fakeDataDist, &norm);
       }
     }

--- a/exec/mcmc.cc
+++ b/exec/mcmc.cc
@@ -448,6 +448,7 @@ void mcmc(const std::string &fitConfigFile_,
     {
       double distInt = postfitDist.Integral();
       systMap[it->first]->SetParameter(it->first, bestFit[it->first]);
+      systMap[it->first]->Construct();
       postfitDist = systMap[it->first]->operator()(postfitDist);
       postfitDist.Scale(distInt);
     }
@@ -474,6 +475,7 @@ void mcmc(const std::string &fitConfigFile_,
     {
       double distInt = postfitDist.Integral();
       systMap[it->first]->SetParameter(it->first, bestFit[it->first]);
+      systMap[it->first]->Construct();
       postfitDist = systMap[it->first]->operator()(postfitDist);
       postfitDist.Scale(distInt);
     }


### PR DESCRIPTION
After setting the parameter values for a systematic, we need to construct the systematic

Without this, fake datasets made with non-nominal systematic values won't work properly, they'll just use the nominal values for the systematics