### PR TITLE
Save Fake Data Components

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -317,7 +317,7 @@ It can be run by doing:
 
 <h4>plotFixedOscDist</h4>
 
-This script will loop over all entries in the output `TTree` from `makeFixedOscTree`, and find the fit with the minimum best LLH. It then goes to the directory of that fit, and plots the distributions saved in the `scaled_dists` directory. The distributions plotted are the data, the total MC (sum of all scaled PDFs with systematics applied), and each individual PDF scaled (without systematics applied). Also saved is a similar plot but with PDFs grouped together. For both plots, a panel showing the ratio of the total MC postfit prediction to the data is plotted below the main histogram.
+This script will loop over all entries in the output `TTree` from `makeFixedOscTree`, and find the fit with the minimum best LLH. It then goes to the directory of that fit, and plots the distributions saved in the `postfit_dists` directory. The distributions plotted are the data, the total MC (sum of all scaled PDFs with systematics applied), and each individual PDF scaled (without systematics applied). Also saved is a similar plot but with PDFs grouped together. For both plots, a panel showing the ratio of the total MC postfit prediction to the data is plotted below the main histogram.
 
 Canvases are saved in both `.root` and `.pdf` files, in the top level output directory of the set of fits. You can run it with:
 
@@ -345,7 +345,7 @@ NOTE: This section is a bit out of date because the code hasn't been brought in 
 
 Now you’re fit has run, the real fun starts! For each individual chain, you’ll have a number of files and subdirectories. In `1dlhproj` and `2dlhproj`, you have projections of the LLH for each parameter, and each combination of two parameters. In each case all other parameters are marginalised over. The burn-in steps, as set in the fit config, are automatically not included.  
 
-`config_log.txt` and `config_log_hmc.txt` save the configs used (these are almost certainly the same as each other). These are also saved in the `cfg` directory if running the python submission script in `util` (see below). `auto_correlations.txt` calculates how correlated the LLH is to the LLH at a step a different number of steps previous. This should hopefully be close to 0 after a few hundred. `fit_results.txt` contains each parameter value for the maximum LLH step. `scaled_dists` contains the PDFs for each event type, scaled by the event type parameter value at the maximum LLH step in this chain. Also saved is the sum of these, with each systematic’s value at the maximum LLH step applied.  
+`config_log.txt` and `config_log_hmc.txt` save the configs used (these are almost certainly the same as each other). These are also saved in the `cfg` directory if running the python submission script in `util` (see below). `auto_correlations.txt` calculates how correlated the LLH is to the LLH at a step a different number of steps previous. This should hopefully be close to 0 after a few hundred. `fit_results.txt` contains each parameter value for the maximum LLH step. `postfit_dists` contains the PDFs for each event type, scaled by the event type parameter value at the maximum LLH step in this chain. Also saved is the sum of these, with each systematic’s value at the maximum LLH step applied.  
 
 There will also be a root file (`fit_name_i.root`) which contains a tree. Each entry in the tree represents a step in the Markov Chain, and the leaves are the values of each parameter, as well as the LLH, step time, and acceptance rate. This is more for MCMC chain diagnostics and debugging than obtaining physics results but is useful for checking the fit has worked as expected.  
 
@@ -355,7 +355,7 @@ There’s an app for making useful plots from the combined tree. This can be run
 
 > ./bin/make_plots output_tree.root asimov_dataset.root scaled_postfit_dist.root fit_config_file.cfg correlations traces
 
-`output_tree.root` is either a single outputted file or the `hadded` combination. `asimov_dataset.root` is the ‘true’ Asimov dataset to get the Asimov rates to compare to. `scaled_postfit_dist.root` is the sum of the PDFs scaled by the maximum LLH step values. If you’ve `hadded` chains, you can find the chain with the highest LLH step (so you know which `scaled_dist` to use) using `util/findMaxStep.C`:  
+`output_tree.root` is either a single outputted file or the `hadded` combination. `asimov_dataset.root` is the ‘true’ Asimov dataset to get the Asimov rates to compare to. `scaled_postfit_dist.root` is the sum of the PDFs scaled by the maximum LLH step values. If you’ve `hadded` chains, you can find the chain with the highest LLH step (so you know which `postfit_dists` to use) using `util/findMaxStep.C`:  
 
 > root -l -b -q 'findMaxStep.C("dataset_directory_name", "fit_name", number_of_chains )'
 

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -163,9 +163,9 @@ This file should contain information about the oscillation grids you want to use
 - `mindm21sq`: The minimum $\Delta m^{2}_{21}$ value of the grid
 - `maxdm21sq`: The maximum $\Delta m^{2}_{21}$ value of the grid
 - `numvalsdm21sq`: The number of grid points on the $\Delta m^{2}_{21}$  axis
-- `minssqth12`: The minimum sin $^2 \theta_{12}$ value of the grid
-- `maxssqth12`: The maximum sin $^2 \theta_{12}$ value of the grid
-- `numvalsssqth12`: The number of grid points on the sin $^2 \theta_{12}$ axis
+- `minssqth12`: The minimum $\text{sin}^2 \theta_{12}$ value of the grid
+- `maxssqth12`: The maximum $\text{sin}^2 \theta_{12}$ value of the grid
+- `numvalsssqth12`: The number of grid points on the $\text{sin}^2 \theta_{12}$ axis
 
 <h2>Apps</h2>
 

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -163,9 +163,9 @@ This file should contain information about the oscillation grids you want to use
 - `mindm21sq`: The minimum $\Delta m^{2}_{21}$ value of the grid
 - `maxdm21sq`: The maximum $\Delta m^{2}_{21}$ value of the grid
 - `numvalsdm21sq`: The number of grid points on the $\Delta m^{2}_{21}$  axis
-- `minssqth12`: The minimum sin$^2 \theta_{12}$ value of the grid
-- `maxssqth12`: The maximum sin$^2 \theta_{12}$value of the grid
-- `numvalsssqth12`: The number of grid points on the sin$^2 \theta_{12}$ axis
+- `minssqth12`: The minimum sin $^2 \theta_{12}$ value of the grid
+- `maxssqth12`: The maximum sin $^2 \theta_{12}$ value of the grid
+- `numvalsssqth12`: The number of grid points on the sin $^2 \theta_{12}$ axis
 
 <h2>Apps</h2>
 
@@ -223,6 +223,8 @@ To run the LLH scan:
 
 > ./bin/llh_scan cfg/fit_config.ini cfg/event_config.ini cfg/pdf_config.ini cfg/syst_config.ini cfg/oscgrid.ini
 
+Both LLH scan apps will also produce several subdirectories inside the `output_directory` set in the `fit_config`. `unscaled_pdfs` will contain each of the unscaled (normalised) PDFs without any systematics applied. `asimov_dists` will contain each of the PDFs scaled to their nominal rates with nominal systematics applied. If you're running with `fake_data = 1` in the `fit_config`, `fakedata_dists` will contain each of the PDFs scaled to their fake data value rate with systematics applied at their fake data values.
+
 <h3>Running a Fit</h3>
 
 Now the time has come to run a fit. When we float the oscillation parameters, we need extra dimensions for the reactors PDF to contain the true neutrino energy and the reactor core it came from. As there are 483 cores, if we have 140 bins in each energy dimension, we end up with over 9 million bins! This means marginalising down to 1D to compare to data takes a lot of time. There are few ideas to get around this, but first let's run individual fits where we don't vary the oscillation parameters (so everything remains 1D and fast), and do this at all points in a grid of oscillation parameter values. We can do this for one point with:
@@ -231,9 +233,13 @@ Now the time has come to run a fit. When we float the oscillation parameters, we
 
 The value of the oscillation parameters should be set in the `fit` config file. This performs a `Minuit` fit, with the oscillation parameters fixed at those values. It will load up all the pdfs, systematics, data etc. and creates the likelihood object in the same way the `llh_scan` app does, and then runs a fit. A variety of output files are produced.
 
-In `1dlhproj` and `2dlhproj`, you have projections of the LLH for each parameter, and each combination of two parameters. In each case, all other parameters are marginalised over.
+`fit_results.txt` contains each parameter value for the maximum LLH point.
 
-`fit_results.txt` contains each parameter value for the maximum LLH point. `scaled_dists` contains the PDFs for each event type, scaled by the event type parameter value at the best fit point. Also saved is the sum of these, with each systematic’s best fit value applied.
+There will also be several subdirectories produced inside the `output_directory` set in the `fit_config`. `unscaled_pdfs` will contain each of the unscaled (normalised) PDFs without any systematics applied. `asimov_dists` will contain each of the PDFs scaled to their nominal rates with nominal systematics applied. If you're running with `fake_data = 1` in the `fit_config`, `fakedata_dists` will contain each of the PDFs scaled to their fake data value rate with systematics applied at their fake data values.
+
+`postfit_dists` contains the PDFs for each event type, scaled by the event type parameter value at the maximum LLH step in this chain, with each systematic’s value at the maximum LLH step applied. Also saved is the sum of these.
+
+In `1dlhproj` and `2dlhproj`, you have projections of the LLH for each parameter, and each combination of two parameters. In each case, all other parameters are marginalised over.
 
 If you want to run a full fit where everything is floated at once, there is an app to run some Markov Chain Monte Carlo. First you want to make sure everything in your fit config is looking sensible. The min and max values, and sigmas for each event type are fairly well tuned, so it's advised you leave these alone unless you know what you're doing. Certainly, for your first fit testing out the code I would leave it as is. If you have good reason to change them, you probably don't need to be reading this guide! You can run a full fit by:
 
@@ -241,9 +247,13 @@ If you want to run a full fit where everything is floated at once, there is an a
 
 This will load up all the pdfs, systematics, data etc. and creates the likelihood object in the same way the `llh_scan` app does, and then runs the MCMC. For each individual chain, you’ll have a number of files and subdirectories, some of which are the same as for `fixedosc_fit`.
 
-In `1dlhproj` and `2dlhproj`, you have projections of the LLH for each parameter, and each combination of two parameters. In each case all other parameters are marginalised over. The burn-in steps are automatically not included.
+`auto_correlations.txt` contains how correlated the LLH is to the LLH at a step a different number of steps previous. This should hopefully be close to 0 after a few thousand steps (there is a separate `autocorrelations` app you can use to run over the outputted tree and get more information). `fit_results.txt` contains each parameter value for the maximum LLH step.
 
-`auto_correlations.txt` contains how correlated the LLH is to the LLH at a step a different number of steps previous. This should hopefully be close to 0 after a few thousand steps (there is a separate `autocorrelations` app you can use to run over the outputted tree and get more information). `fit_results.txt` contains each parameter value for the maximum LLH step. `scaled_dists` contains the PDFs for each event type, scaled by the event type parameter value at the maximum LLH step in this chain. Also saved is the sum of these, with each systematic’s value at the maximum LLH step applied.
+There will also be several subdirectories produced inside the `output_directory` set in the `fit_config`. `unscaled_pdfs` will contain each of the unscaled (normalised) PDFs without any systematics applied. `asimov_dists` will contain each of the PDFs scaled to their nominal rates with nominal systematics applied. If you're running with `fake_data = 1` in the `fit_config`, `fakedata_dists` will contain each of the PDFs scaled to their fake data value rate with systematics applied at their fake data values.
+
+`postfit_dists` contains the PDFs for each event type, scaled by the event type parameter value at the maximum LLH step in this chain, with each systematic’s value at the maximum LLH step applied. Also saved is the sum of these.
+
+In `1dlhproj` and `2dlhproj`, you have projections of the LLH for each parameter, and each combination of two parameters. In each case all other parameters are marginalised over. The burn-in steps are automatically not included.
 
 There will also be a root file (`fit_name_i.root`) which contains a tree. Each entry in the tree represents a step in the Markov Chain, and the leaves are the values of each parameter, as well as the LLH, step time, and acceptance rate. This is more for MCMC chain diagnostics and debugging than obtaining physics results but is useful for checking the fit has worked as expected.
 

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -330,8 +330,6 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
         fakeDataDist = systIt->second->operator()(fakeDataDist, &norm);
       }
     }
-    dist.Scale(noms[it->first]);
-    fakeDataDist.Scale(fdValues[it->first]);
 
     // Now scale the Asimov component by expected count, and also save pdf as a histo
     dist.Scale(noms[it->first]);

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -49,14 +49,19 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   std::map<std::string, std::string> constrCorrParName = fitConfig.GetConstrCorrParName();
   ParameterDict fdValues = fitConfig.GetFakeDataVals();
 
+  std::string pdfDir = outDir + "/unscaled_pdfs";
+  std::string asimovDistDir = outDir + "/asimov_dists";
+  std::string fakedataDistDir = outDir + "/fakedata_dists";
   // Create output directories
   struct stat st = {0};
   if (stat(outDir.c_str(), &st) == -1)
     mkdir(outDir.c_str(), 0700);
-
-  std::string pdfDir = outDir + "/pdfs";
   if (stat(pdfDir.c_str(), &st) == -1)
     mkdir(pdfDir.c_str(), 0700);
+  if (stat(asimovDistDir.c_str(), &st) == -1)
+    mkdir(asimovDistDir.c_str(), 0700);
+  if (stat(fakedataDistDir.c_str(), &st) == -1)
+    mkdir(fakedataDistDir.c_str(), 0700);
 
   // Load up all the event types we want to contribute
   typedef std::map<std::string, EventConfig> EvMap;
@@ -207,6 +212,8 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
 
     // Build distribution of those events
     BinnedED dist;
+    BinnedED fakeDataDist;
+    BinnedED unscaledPDF;
     int num_dimensions = it->second.GetNumDimensions();
 
     // If it's the reactor PDF, two things are different from the others. Firstly we use the BuildOscillatedDist rather than just Build.
@@ -287,19 +294,22 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       dist = DistBuilder::Build(it->first, num_dimensions, pdfConfig, dataSet);
     }
 
+    // Now make a fake data dist for the event type
+    fakeDataDist = dist;
+
     // Save the generated number of events for Beeston Barlow
     genRates.push_back(dist.Integral());
 
     // Scale for PDF and add to vector
-    if (dist.Integral())
+    if (dist.Integral() && fakeDataDist.Integral())
+    {
       dist.Normalise();
+      fakeDataDist.Normalise();
+    }
     pdfs.push_back(dist);
+    unscaledPDF = dist;
 
     norm_fitting_statuses->push_back(INDIRECT);
-
-    // Now make a fake data dist for the event type
-    BinnedED fakeDataDist = dist;
-    double distInt = dist.Integral();
 
     // Apply nominal systematic variables
     for (std::map<std::string, Systematic *>::iterator systIt = systMap.begin(); systIt != systMap.end(); ++systIt)
@@ -320,8 +330,8 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
         fakeDataDist = systIt->second->operator()(fakeDataDist, &norm);
       }
     }
-    dist.Scale(distInt);
-    fakeDataDist.Scale(distInt);
+    dist.Scale(noms[it->first]);
+    fakeDataDist.Scale(fdValues[it->first]);
 
     // Now scale the Asimov component by expected count, and also save pdf as a histo
     dist.Scale(noms[it->first]);
@@ -330,19 +340,23 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
     {
       BinnedED marginalised = dist.Marginalise(dataObs);
       asimov.Add(marginalised);
-      IO::SaveHistogram(marginalised.GetHistogram(), pdfDir + "/" + it->first + ".root", dist.GetName());
+      BinnedED marginalisedPDF = unscaledPDF.Marginalise(dataObs);
+      IO::SaveHistogram(marginalised.GetHistogram(), asimovDistDir + "/" + it->first + ".root", dist.GetName());
+      IO::SaveHistogram(marginalisedPDF.GetHistogram(), pdfDir + "/" + it->first + ".root", unscaledPDF.GetName());
 
       // Also scale fake data dist by fake data value
       if (isFakeData)
       {
         BinnedED marginalisedFakeData = fakeDataDist.Marginalise(dataObs);
         fakeDataset.Add(marginalisedFakeData);
+        IO::SaveHistogram(marginalisedFakeData.GetHistogram(), fakedataDistDir + "/" + it->first + ".root", fakeDataDist.GetName());
       }
     }
     else
     {
       asimov.Add(dist);
-      IO::SaveHistogram(dist.GetHistogram(), pdfDir + "/" + it->first + ".root", dist.GetName());
+      IO::SaveHistogram(dist.GetHistogram(), asimovDistDir + "/" + it->first + ".root", dist.GetName());
+      IO::SaveHistogram(unscaledPDF.GetHistogram(), pdfDir + "/" + it->first + ".root", unscaledPDF.GetName());
       // For the non-reactor PDFs, add to the oscillated asimovs too!
       if (it->first != "reactor_nubar")
       {
@@ -355,6 +369,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       if (isFakeData)
       {
         fakeDataset.Add(fakeDataDist);
+        IO::SaveHistogram(fakeDataDist.GetHistogram(), fakedataDistDir + "/" + it->first + ".root", fakeDataDist.GetName());
       }
     }
   } // End loop over PDFs

--- a/exec/llh_scan.cc
+++ b/exec/llh_scan.cc
@@ -49,14 +49,19 @@ void llh_scan(const std::string &fitConfigFile_,
   std::map<std::string, std::string> constrCorrParName = fitConfig.GetConstrCorrParName();
   ParameterDict fdValues = fitConfig.GetFakeDataVals();
 
+  std::string pdfDir = outDir + "/unscaled_pdfs";
+  std::string asimovDistDir = outDir + "/asimov_dists";
+  std::string fakedataDistDir = outDir + "/fakedata_dists";
   // Create output directories
   struct stat st = {0};
   if (stat(outDir.c_str(), &st) == -1)
     mkdir(outDir.c_str(), 0700);
-
-  std::string pdfDir = outDir + "/pdfs";
   if (stat(pdfDir.c_str(), &st) == -1)
     mkdir(pdfDir.c_str(), 0700);
+  if (stat(asimovDistDir.c_str(), &st) == -1)
+    mkdir(asimovDistDir.c_str(), 0700);
+  if (stat(fakedataDistDir.c_str(), &st) == -1)
+    mkdir(fakedataDistDir.c_str(), 0700);
 
   // Load up all the event types we want to contribute
   typedef std::map<std::string, EventConfig> EvMap;
@@ -187,21 +192,30 @@ void llh_scan(const std::string &fitConfigFile_,
 
     // Build distribution of those events
     BinnedED dist;
+    BinnedED fakeDataDist;
+    BinnedED unscaledPDF;
     int num_dimensions = it->second.GetNumDimensions();
     dist = DistBuilder::Build(it->first, num_dimensions, pdfConfig, dataSet);
+
+    // Now make a fake data dist for the event type
+    fakeDataDist = dist;
 
     // Save the generated number of events for Beeston Barlow
     genRates.push_back(dist.Integral());
 
     // Scale for PDF and add to vector
-    if (dist.Integral())
+    if (dist.Integral() && fakeDataDist.Integral())
+    {
       dist.Normalise();
+      fakeDataDist.Normalise();
+    }
     pdfs.push_back(dist);
+    unscaledPDF = dist;
 
     norm_fitting_statuses->push_back(INDIRECT);
 
-    // Now make a fake data dist for the event type
-    BinnedED fakeDataDist = dist;
+    // Now make fake data dist for the event type
+    fakeDataDist = dist;
 
     double distInt = dist.Integral();
     double norm;
@@ -232,23 +246,28 @@ void llh_scan(const std::string &fitConfigFile_,
     {
       BinnedED marginalised = dist.Marginalise(dataObs);
       asimov.Add(marginalised);
-      IO::SaveHistogram(marginalised.GetHistogram(), pdfDir + "/" + it->first + ".root", dist.GetName());
+      BinnedED marginalisedPDF = unscaledPDF.Marginalise(dataObs);
+      IO::SaveHistogram(marginalised.GetHistogram(), asimovDistDir + "/" + it->first + ".root", dist.GetName());
+      IO::SaveHistogram(marginalisedPDF.GetHistogram(), pdfDir + "/" + it->first + ".root", unscaledPDF.GetName());
 
       // Also scale fake data dist by fake data value
       if (isFakeData)
       {
         BinnedED marginalisedFakeData = fakeDataDist.Marginalise(dataObs);
         fakeDataset.Add(marginalisedFakeData);
+        IO::SaveHistogram(marginalisedFakeData.GetHistogram(), fakedataDistDir + "/" + it->first + ".root", fakeDataDist.GetName());
       }
     }
     else
     {
       asimov.Add(dist);
-      IO::SaveHistogram(dist.GetHistogram(), pdfDir + "/" + it->first + ".root", dist.GetName());
+      IO::SaveHistogram(dist.GetHistogram(), asimovDistDir + "/" + it->first + ".root", dist.GetName());
+      IO::SaveHistogram(unscaledPDF.GetHistogram(), pdfDir + "/" + it->first + ".root", unscaledPDF.GetName());
       // Also scale fake data dist by fake data value
       if (isFakeData)
       {
         fakeDataset.Add(fakeDataDist);
+        IO::SaveHistogram(fakeDataDist.GetHistogram(), fakedataDistDir + "/" + it->first + ".root", fakeDataDist.GetName());
       }
     }
   }

--- a/exec/mcmc.cc
+++ b/exec/mcmc.cc
@@ -56,23 +56,25 @@ void mcmc(const std::string &fitConfigFile_,
   ParameterDict fdValues = fitConfig.GetFakeDataVals();
   double sigmaScale = fitConfig.GetSigmaScale();
 
+  std::string pdfDir = outDir + "/unscaled_pdfs";
+  std::string asimovDistDir = outDir + "/asimov_dists";
+  std::string fakedataDistDir = outDir + "/fakedata_dists";
+  std::string postfitDistDir = outDir + "/postfit_dists";
+  std::string projDir1D = outDir + "/1dlhproj";
+  std::string projDir2D = outDir + "/2dlhproj";
+
   // Create output directories
   struct stat st = {0};
   if (stat(outDir.c_str(), &st) == -1)
     mkdir(outDir.c_str(), 0700);
-
-  std::string projDir1D = outDir + "/1dlhproj";
-  std::string projDir2D = outDir + "/2dlhproj";
-  std::string scaledDistDir = outDir + "/scaled_dists";
-  std::string pdfDir = outDir + "/pdfs";
-  if (stat(projDir1D.c_str(), &st) == -1)
-    mkdir(projDir1D.c_str(), 0700);
-  if (stat(projDir2D.c_str(), &st) == -1)
-    mkdir(projDir2D.c_str(), 0700);
-  if (stat(scaledDistDir.c_str(), &st) == -1)
-    mkdir(scaledDistDir.c_str(), 0700);
   if (stat(pdfDir.c_str(), &st) == -1)
     mkdir(pdfDir.c_str(), 0700);
+  if (stat(asimovDistDir.c_str(), &st) == -1)
+    mkdir(asimovDistDir.c_str(), 0700);
+  if (stat(fakedataDistDir.c_str(), &st) == -1)
+    mkdir(fakedataDistDir.c_str(), 0700);
+  if (stat(postfitDistDir.c_str(), &st) == -1)
+    mkdir(postfitDistDir.c_str(), 0700);
 
   // Load up all the event types we want to contribute
   typedef std::map<std::string, EventConfig> EvMap;
@@ -205,6 +207,8 @@ void mcmc(const std::string &fitConfigFile_,
 
     // Build distribution of those events
     BinnedED dist;
+    BinnedED fakeDataDist;
+    BinnedED unscaledPDF;
     int num_dimensions = it->second.GetNumDimensions();
     dist = DistBuilder::Build(it->first, num_dimensions, pdfConfig, dataSet);
 
@@ -212,13 +216,18 @@ void mcmc(const std::string &fitConfigFile_,
     genRates.push_back(dist.Integral());
 
     // Scale for PDF and add to vector
-    if (dist.Integral())
+    if (dist.Integral() && fakeDataDist.Integral())
+    {
       dist.Normalise();
+      fakeDataDist.Normalise();
+    }
     pdfs.push_back(dist);
+    unscaledPDF = dist;
+
     norm_fitting_statuses->push_back(INDIRECT);
 
-    // Now make a fake data dist for the event type
-    BinnedED fakeDataDist = dist;
+    // Now make fake data dist for the event type
+    fakeDataDist = dist;
 
     // Apply nominal systematic variables
     for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)
@@ -239,23 +248,29 @@ void mcmc(const std::string &fitConfigFile_,
     {
       BinnedED marginalised = dist.Marginalise(dataObs);
       asimov.Add(marginalised);
-      IO::SaveHistogram(marginalised.GetHistogram(), pdfDir + "/" + it->first + ".root", dist.GetName());
+      BinnedED marginalisedPDF = unscaledPDF.Marginalise(dataObs);
+      IO::SaveHistogram(marginalised.GetHistogram(), asimovDistDir + "/" + it->first + ".root", dist.GetName());
+      IO::SaveHistogram(marginalisedPDF.GetHistogram(), pdfDir + "/" + it->first + ".root", unscaledPDF.GetName());
 
       // Also scale fake data dist by fake data value
       if (isFakeData)
       {
         BinnedED marginalisedFakeData = fakeDataDist.Marginalise(dataObs);
         fakeDataset.Add(marginalisedFakeData);
+        IO::SaveHistogram(marginalisedFakeData.GetHistogram(), fakedataDistDir + "/" + it->first + ".root", fakeDataDist.GetName());
       }
     }
     else
     {
       asimov.Add(dist);
-      IO::SaveHistogram(dist.GetHistogram(), pdfDir + "/" + it->first + ".root", dist.GetName());
+      IO::SaveHistogram(dist.GetHistogram(), asimovDistDir + "/" + it->first + ".root", dist.GetName());
+      IO::SaveHistogram(unscaledPDF.GetHistogram(), pdfDir + "/" + it->first + ".root", unscaledPDF.GetName());
+
       // Also scale fake data dist by fake data value
       if (isFakeData)
       {
         fakeDataset.Add(fakeDataDist);
+        IO::SaveHistogram(fakeDataDist.GetHistogram(), fakedataDistDir + "/" + it->first + ".root", fakeDataDist.GetName());
       }
     }
   }
@@ -430,7 +445,7 @@ void mcmc(const std::string &fitConfigFile_,
   postfitDist.Empty();
 
   // Scale the distributions to the correct heights. They are named the same as their fit parameters
-  std::cout << "Saving scaled histograms and data to \n\t" << scaledDistDir << std::endl;
+  std::cout << "Saving scaled histograms and data to \n\t" << postfitDistDir << std::endl;
 
   if (dataDist.GetHistogram().GetNDims() < 3)
   {
@@ -439,21 +454,28 @@ void mcmc(const std::string &fitConfigFile_,
     {
       std::string name = pdfs.at(i).GetName();
       pdfs[i].Normalise();
+      for (std::map<std::string, Systematic *>::iterator systIt = systMap.begin(); systIt != systMap.end(); ++systIt)
+      {
+        // If group is "", we apply to all groups
+        if (systGroup[systIt->first] == "" || std::find(pdfGroups.back().begin(), pdfGroups.back().end(), systGroup[systIt->first]) != pdfGroups.back().end())
+        {
+          std::set<std::string> systParamNames = systMap[systIt->first]->GetParameterNames();
+          for (auto itSystParam = systParamNames.begin(); itSystParam != systParamNames.end(); ++itSystParam)
+          {
+            systMap[systIt->first]->SetParameter(*itSystParam, bestFit[*itSystParam]);
+          }
+          double norm;
+          systIt->second->Construct();
+          pdfs[i] = systIt->second->operator()(pdfs[i], &norm);
+        }
+      }
       pdfs[i].Scale(bestFit[name]);
-      IO::SaveHistogram(pdfs[i].GetHistogram(), scaledDistDir + "/" + name + ".root");
+      IO::SaveHistogram(pdfs[i].GetHistogram(), postfitDistDir + "/" + name + ".root");
       // Sum all scaled distributions to get full postfit "dataset"
       postfitDist.Add(pdfs[i]);
     }
 
-    for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)
-    {
-      double distInt = postfitDist.Integral();
-      systMap[it->first]->SetParameter(it->first, bestFit[it->first]);
-      systMap[it->first]->Construct();
-      postfitDist = systMap[it->first]->operator()(postfitDist);
-      postfitDist.Scale(distInt);
-    }
-    IO::SaveHistogram(postfitDist.GetHistogram(), scaledDistDir + "/postfitdist.root");
+    IO::SaveHistogram(postfitDist.GetHistogram(), postfitDistDir + "/postfitdist.root");
   }
   else
   {
@@ -462,38 +484,46 @@ void mcmc(const std::string &fitConfigFile_,
     {
       std::string name = pdfs.at(i).GetName();
       pdfs[i].Normalise();
+      // Apply bestfit systematic variables
+      for (std::map<std::string, Systematic *>::iterator systIt = systMap.begin(); systIt != systMap.end(); ++systIt)
+      {
+        // If group is "", we apply to all groups
+        if (systGroup[systIt->first] == "" || std::find(pdfGroups.back().begin(), pdfGroups.back().end(), systGroup[systIt->first]) != pdfGroups.back().end())
+        {
+          std::set<std::string> systParamNames = systMap[systIt->first]->GetParameterNames();
+          for (auto itSystParam = systParamNames.begin(); itSystParam != systParamNames.end(); ++itSystParam)
+          {
+            systMap[systIt->first]->SetParameter(*itSystParam, bestFit[*itSystParam]);
+          }
+          double norm;
+          systIt->second->Construct();
+          pdfs[i] = systIt->second->operator()(pdfs[i], &norm);
+        }
+      }
       pdfs[i].Scale(bestFit[name]);
 
       std::vector<std::string> keepObs;
       keepObs.push_back("energy");
       pdfs[i] = pdfs[i].Marginalise(keepObs);
-      IO::SaveHistogram(pdfs[i].GetHistogram(), scaledDistDir + "/" + name + ".root");
+      IO::SaveHistogram(pdfs[i].GetHistogram(), postfitDistDir + "/" + name + ".root");
       // Sum all scaled distributions to get full postfit "dataset"
       postfitDist.Add(pdfs[i]);
     }
 
-    for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it)
-    {
-      double distInt = postfitDist.Integral();
-      systMap[it->first]->SetParameter(it->first, bestFit[it->first]);
-      systMap[it->first]->Construct();
-      postfitDist = systMap[it->first]->operator()(postfitDist);
-      postfitDist.Scale(distInt);
-    }
-    IO::SaveHistogram(postfitDist.GetHistogram(), scaledDistDir + "/postfitdist.root");
+    IO::SaveHistogram(postfitDist.GetHistogram(), postfitDistDir + "/postfitdist.root");
   }
 
   // And also save the data
   if (dataDist.GetHistogram().GetNDims() < 3)
   {
-    IO::SaveHistogram(dataDist.GetHistogram(), scaledDistDir + "/" + "data.root");
+    IO::SaveHistogram(dataDist.GetHistogram(), outDir + "/" + "data.root");
   }
   else
   {
     std::vector<std::string> keepObs;
     keepObs.push_back("energy");
     dataDist = dataDist.Marginalise(keepObs);
-    IO::SaveHistogram(dataDist.GetHistogram(), scaledDistDir + "/" + "data.root");
+    IO::SaveHistogram(dataDist.GetHistogram(), outDir + "/" + "data.root");
   }
 
   // Save autocorrelations

--- a/util/findMaxStep.C
+++ b/util/findMaxStep.C
@@ -2,7 +2,7 @@
 #include <TTree.h>
 
 // Script to loop over a bunch of parallel MCMC trees and find which file contained
-// the step with the highest LLH. Useful for getting the correct scaled_dist file 
+// the step with the highest LLH. Useful for getting the correct postfit_dists file 
 // to input to make_plots
 
 // dataset_dir is level above the fit_dir

--- a/util/plotFixedOscDist.C
+++ b/util/plotFixedOscDist.C
@@ -15,7 +15,7 @@
 /// First open the root file (made by makeFixedOscTree) and find the
 /// minimum LLH entry.
 /// Then go into the corresponding fit directory and load up the
-/// histograms from scaled_dists
+/// histograms from postfit_dists
 /// Loop through these and plot, and also add to groups for a separate
 /// groups plot.
 ///
@@ -109,7 +109,7 @@ void plotFixedOscDist(const char *filename = "fit_results.root")
     directory << dirPath.string() << "/th" << std::fixed << std::setprecision(2) << bestTheta
               << "/th" << std::fixed << std::setprecision(2) << bestTheta
               << "_dm" << std::fixed << std::setprecision(8) << bestDeltaM
-              << "/scaled_dists/";
+              << "/postfit_dists/";
 
     TLegend *t1 = new TLegend(0.5, 0.48, 0.85, 0.85);
     t1->SetLineWidth(2);

--- a/util/plotFixedOscDist.C
+++ b/util/plotFixedOscDist.C
@@ -121,11 +121,23 @@ void plotFixedOscDist(const char *filename = "fit_results.root")
     std::vector<int> fillColours = {kBlack, kBlue - 9, kMagenta - 8, kMagenta - 5, kRed - 1, kRed - 2, kRed - 9, kGreen - 5};
     int colourIndex = 0;
 
-    // Go into scaled dists and loop over each file
+    std::vector<std::filesystem::path> postfit_files;
+
+    // Add files from the postfit_dists directory
     for (const auto &entry : std::filesystem::directory_iterator(directory.str()))
     {
+        postfit_files.push_back(entry.path());
+    }
 
-        std::string filePath = entry.path().string();
+    // Add data files
+    std::filesystem::path parent = std::filesystem::path(directory.str() + "/../");
+    postfit_files.push_back(parent / "data.root");
+
+    // Go into scaled dists and loop over each file
+    for (const auto &entry : postfit_files)
+    {
+
+        std::string filePath = entry.string();
         std::filesystem::path pathObj(filePath);
 
         // Check if it's a .root file


### PR DESCRIPTION
Save the individual scaled PDFs with systematics applied that make up the fake data set if we're using one.

We also save the unscaled (normalised) PDFs without systematics applied

And rename the postfit scaled PDFs (with systs applied) so the output directory name is clearer

For the non-fixed osc param fit apps, we weren't really using the fake data functionality so I include that too here. So we might want to some proper validations on those before merging

I also update plotting apps to look in the updated location, and update the docs too