### PR TITLE
Safer check of non-entry in maps

### DIFF
--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -392,7 +392,7 @@ void fixedosc_fit(const std::string &fitConfigFile_,
   for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
   {
     // Only add single parameter constraint if correlation hasn't already been applied
-    if (!constrCorrs[it->first] && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
+    if (constrCorrs.find(it->first) == constrCorrs.end() && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
       lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
   }
   for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -159,7 +159,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   }
 
   PrintParams(noms, mins, maxs, constrMeans, constrSigmas, constrRatioMeans, constrRatioSigmas, constrRatioParName, constrCorrs, constrCorrParName);
-
+ 
   // Create the individual PDFs and Asimov components
   std::vector<BinnedED> pdfs;
   std::vector<int> genRates;
@@ -436,7 +436,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
   {
     // Only add single parameter constraint if correlation hasn't already been applied
-    if (!constrCorrs[it->first] && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
+    if (constrCorrs.find(it->first) == constrCorrs.end() && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
       lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
   }
   for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
@@ -568,7 +568,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
     for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
     {
       // Only add single parameter constraint if correlation hasn't already been applied
-      if (!constrCorrs[it->first] && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
+      if (constrCorrs.find(it->first) == constrCorrs.end() && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
         osclh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
     }
     for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)
@@ -631,7 +631,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
     for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
     {
       // Only add single parameter constraint if correlation hasn't already been applied
-      if (!constrCorrs[it->first] && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
+      if (constrCorrs.find(it->first) == constrCorrs.end() && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
         osclh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
     }
     for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -159,7 +159,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   }
 
   PrintParams(noms, mins, maxs, constrMeans, constrSigmas, constrRatioMeans, constrRatioSigmas, constrRatioParName, constrCorrs, constrCorrParName);
- 
+
   // Create the individual PDFs and Asimov components
   std::vector<BinnedED> pdfs;
   std::vector<int> genRates;

--- a/exec/llh_scan.cc
+++ b/exec/llh_scan.cc
@@ -316,7 +316,7 @@ void llh_scan(const std::string &fitConfigFile_,
   for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
   {
     // Only add single parameter constraint if correlation hasn't already been applied
-    if (!constrCorrs[it->first] && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
+    if (constrCorrs.find(it->first) == constrCorrs.end() && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
       lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
   }
   for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)

--- a/exec/mcmc.cc
+++ b/exec/mcmc.cc
@@ -323,7 +323,7 @@ void mcmc(const std::string &fitConfigFile_,
   for (ParameterDict::iterator it = constrMeans.begin(); it != constrMeans.end(); ++it)
   {
     // Only add single parameter constraint if correlation hasn't already been applied
-    if (!constrCorrs[it->first] && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
+    if (constrCorrs.find(it->first) == constrCorrs.end() && std::find(corrPairs.begin(), corrPairs.end(), it->first) == corrPairs.end())
       lh.SetConstraint(it->first, it->second, constrSigmas.at(it->first));
   }
   for (ParameterDict::iterator it = constrRatioMeans.begin(); it != constrRatioMeans.end(); ++it)


### PR DESCRIPTION
When we do `!map["key"] ` to check if an element doesn't exist, we inadvertently create the element! So the next time we check or loop over elements in that map things go wrong

This PR just avoids that