### PR TITLE
Getting the Covariance Matrix Properly

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -233,7 +233,7 @@ Now the time has come to run a fit. When we float the oscillation parameters, we
 
 The value of the oscillation parameters should be set in the `fit` config file. This performs a `Minuit` fit, with the oscillation parameters fixed at those values. It will load up all the pdfs, systematics, data etc. and creates the likelihood object in the same way the `llh_scan` app does, and then runs a fit. A variety of output files are produced.
 
-`fit_results.txt` contains each parameter value for the maximum LLH point.
+`fit_results.txt` contains each parameter value for the maximum LLH point, and `fit_results.root` contains the vectors of parameter names, postfit values and uncertainties, and a covariance matrix.
 
 There will also be several subdirectories produced inside the `output_directory` set in the `fit_config`. `unscaled_pdfs` will contain each of the unscaled (normalised) PDFs without any systematics applied. `asimov_dists` will contain each of the PDFs scaled to their nominal rates with nominal systematics applied. If you're running with `fake_data = 1` in the `fit_config`, `fakedata_dists` will contain each of the PDFs scaled to their fake data value rate with systematics applied at their fake data values.
 
@@ -303,7 +303,7 @@ The config files should be ones you've used to run one of the fits. If this take
 
 > python utils/submitCondor.py makeFixedOscTree output_dir -r /path/to/this/repo/ -e /path/to/env/file/ -f cfg/fit_config.ini-o cfg/oscgrid.ini -w walltime
 
-Once the tree is made, the it finds the fit that had the best LLH, and reruns that fit with the `save_outputs` bool in the fit config set to true.
+Once the tree is made, the it finds the fit that had the best LLH, and reruns that fit with the `save_outputs` bool in the fit config set to true. The covariance matrix from this fit is saved along with the tree of fit results.
 
 <h4>plotFixedOscLLH</h4>
 
@@ -328,6 +328,8 @@ In this script Latex labels are made for each PDF (currently reactor IBDs, Geo U
 <h4>plotFixedOscParams</h4>
 
 This script loops over all entries in the output `TTree` from `makeFixedOscTree`, and finds the fit with the minimum best LLH. It then plots each parameter in that entry, relative to it's nominal value. Any prefit constraints are also plotted, relative to nominal values. A canvas is saved in both a `.root` and `.pdf` file, in the top level output directory of the set of fits. The constraint, nominal, and postfit histograms are also saved in the root file. If `plotFixedOscLLH` has already been run, it will look for the outputted `LLH.root` file to find the oscillation parameter uncertainties. Otherwise, it will use the grid spacing.
+
+A separate canvas is also saved, containing a plot of the postfit correlation matrix of all fit parameters.
 
 You can run it with:
 

--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -271,9 +271,10 @@ void fixedosc_fit(const std::string &fitConfigFile_,
       BinnedED marginalised = dist.Marginalise(dataObs);
       asimov.Add(marginalised);
       BinnedED marginalisedPDF = unscaledPDF.Marginalise(dataObs);
-      if (saveOutputs){
+      if (saveOutputs)
+      {
         IO::SaveHistogram(marginalised.GetHistogram(), asimovDistDir + "/" + it->first + ".root", dist.GetName());
-        IO::SaveHistogram(marginalisedPDF.GetHistogram(), pdfDir + "/" + it->first + ".root", unscaledPDF.GetName()); 
+        IO::SaveHistogram(marginalisedPDF.GetHistogram(), pdfDir + "/" + it->first + ".root", unscaledPDF.GetName());
       }
       // Also scale fake data dist by fake data value
       if (isFakeData)
@@ -287,7 +288,8 @@ void fixedosc_fit(const std::string &fitConfigFile_,
     else
     {
       asimov.Add(dist);
-      if (saveOutputs){
+      if (saveOutputs)
+      {
         IO::SaveHistogram(dist.GetHistogram(), asimovDistDir + "/" + it->first + ".root", dist.GetName());
         IO::SaveHistogram(unscaledPDF.GetHistogram(), pdfDir + "/" + it->first + ".root", unscaledPDF.GetName());
       }
@@ -465,7 +467,11 @@ void fixedosc_fit(const std::string &fitConfigFile_,
       if (validFit)
       {
         paramErr.push_back(sqrt(covMatrix.GetComponent(paramNames.size() - 1, paramNames.size() - 1)));
-        covTMatrixD[paramNames.size() - 1][paramNames.size() - 1] = covMatrix.GetComponent(paramNames.size() - 1, paramNames.size() - 1);
+        for (int iParam = 0; iParam < paramNames.size(); iParam++)
+        {
+          covTMatrixD[paramNames.size() - 1][iParam] = covMatrix.GetComponent(paramNames.size() - 1, iParam);
+          covTMatrixD[iParam][paramNames.size() - 1] = covMatrix.GetComponent(iParam, paramNames.size() - 1);
+        }
       }
     }
     paramNames.push_back("LLH");
@@ -476,7 +482,7 @@ void fixedosc_fit(const std::string &fitConfigFile_,
     outFile->WriteObject(&paramVals, "paramVals");
     outFile->WriteObject(&paramErr, "paramErr");
     outFile->WriteObject(&covTMatrixD, "covMatrix");
-    std::cout << "Saved fit result to " << outDir + "/fit_result.txt and " << outDir << "r/fit_result.root" << std::endl;
+    std::cout << "Saved fit result to " << outDir + "/fit_result.txt and " << outDir << "/fit_result.root" << std::endl;
 
     // Initialise postfit distributions to same axis as data
     BinnedED postfitDist;


### PR DESCRIPTION
The final problem was I wasn't reading all the elements properly!

This solves that. The matrix then gets saved in the fitting code, and also written to the file containing the big TTree if you run makeFixedOscTree. Finally, plotFixedOscParams is updated to also plot the correlation matrix (calculated from the covariance matrix and reordering elements) and the docs are updated accordingly

It should only really affect postfit plotting so I don't think there's much danger of it breaking everything, so I'll probably merge it in soon