### PR TITLE
Options to fit in sin(theta12) and sin^2(theta12)

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -205,7 +205,7 @@ This app also divides the three alpha-n processes into different files. They are
 
 Right, we've now pruned our trees and can use them to build PDFs and a simulated dataset(s). In theory, we're now ready to launch a fit! But let's be steady Eddies, Cautious Carols, and Nervous Nigels, and make sure everything is behaving as intended. Running fits can be computationally and storage expensive, so it would be a shame to find out after running them that something had previously gone wrong.  
 
-One of way doing this is with likelihood scans. The likelihood scan apps first build the same test statistic that the fit will use, and we will hand it the same PDFs, parameters, and systematics we intend to hand the fitter. For a single floated parameter, it will scan over a range of values centred at the nominal value. For each of 150 steps, it will rebuild the dataset by scaling the PDFs and applying any systematics all set at their nominal values, except the parameter in question which is set to the value we've reached in the scan. This is compared to the actual dataset using the test statistic (probably the binned LLH). The LLH (minus the nominal LLH) is saved at each step, and once we reach the end of the scan for a parameter, it is set back to its nominal value, and we repeat for the next parameter.  
+One way of doing this is with likelihood scans. The likelihood scan apps first build the same test statistic that the fit will use, and we will hand it the same PDFs, parameters, and systematics we intend to hand the fitter. For a single floated parameter, it will scan over a range of values centred at the nominal value. For each of 150 steps, it will rebuild the dataset by scaling the PDFs and applying any systematics all set at their nominal values, except the parameter in question which is set to the value we've reached in the scan. This is compared to the actual dataset using the test statistic (probably the binned LLH). The LLH (minus the nominal LLH) is saved at each step, and once we reach the end of the scan for a parameter, it is set back to its nominal value, and we repeat for the next parameter.  
 
 For the 'true' Asimov dataset, these scans should all minimise at (1,0) (where the x axis is parameter value / nominal value) i.e., by changing a parameter, you can't produce a dataset more similar to the target dataset than by using the exact values used to produce the target dataset. For the other forms of Asimov dataset, most parameters will minimise close to 1, but probably not exactly. The event types with higher rates will be closer to 1 as changes in these will have a greater impact on the LLH, and the small fluctuations causing the differences between the PDFs and Asimov dataset will be smaller proportionally.  
 
@@ -215,7 +215,7 @@ To run the fixedosc LLH scan:
 
 > ./bin/fixedosc_llhscan cfg/fit_config.ini cfg/event_config.ini cfg/pdf_config.ini cfg/syst_config.ini cfg/oscgrid.ini
 
-A root file `llh_scan.root` will be saved in the output directory specified in the fit config. In the file will be a plot of LLH vs parameter value for each parameter.
+You will need to have a `deltam21` parameter, and exactly one `theta12`, `sintheta12`, or `sinsqtheta12` parameter specified in the fit config. A root file `llh_scan.root` will be saved in the output directory specified in the fit config. In the file will be a plot of LLH vs parameter value for each parameter.
 
 The other version of the likelihood scan, `llh_scan`, hands all the parameters, including the oscillation parameters, to the `BinnedNLLH`. It then scans through all parameters in the same way, setting the values in the `BinnedNLLH` and evaluating the likelihood. This version of the likelihood scan is designed to be used for validating the full fits where every parameter floats at once (see below).
 
@@ -231,7 +231,7 @@ Now the time has come to run a fit. When we float the oscillation parameters, we
 
 > ./bin/fixedosc_fit cfg/fit_config.ini cfg/event_config.ini cfg/pdf_config.ini cfg/syst_config.ini cfg/oscgrid.ini
 
-The value of the oscillation parameters should be set in the `fit` config file. This performs a `Minuit` fit, with the oscillation parameters fixed at those values. It will load up all the pdfs, systematics, data etc. and creates the likelihood object in the same way the `llh_scan` app does, and then runs a fit. A variety of output files are produced.
+The value of the oscillation parameters should be set in the `fit` config file. You will need to have a `deltam21` parameter, and exactly one `theta12`, `sintheta12`, or `sinsqtheta12` parameter. This performs a `Minuit` fit, with the oscillation parameters fixed at those values. It will load up all the pdfs, systematics, data etc. and creates the likelihood object in the same way the `llh_scan` app does, and then runs a fit. A variety of output files are produced.
 
 `fit_results.txt` contains each parameter value for the maximum LLH point, and `fit_results.root` contains the vectors of parameter names, postfit values and uncertainties, and a covariance matrix.
 

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -259,9 +259,9 @@ There will also be a root file (`fit_name_i.root`) which contains a tree. Each e
 
 <h2>Submitting Batch Jobs</h2>
 
-<h3>Full fits</h3>
+<h3>Individual Jobs</h3>
 
-For running full fits, it’s advisable to run multiple fits at once in parallel as you probably want around 1 million steps. Every batch system will be different, but for submitting to a Condor based queue system there is a script, `util/submitCondor.py`, based on one for submitting RAT jobs originally from Josie (I think).  
+Every batch system will be different, but for submitting to a Condor based queue system there is a script, `util/submitCondor.py`, based on one for submitting RAT jobs originally from Josie (I think). You can use this for any exectuable. For running full MCMC fits, it’s advisable to run multiple identical fits at once in parallel as you probably want around 1 million steps.   
 
 You can submit N jobs with:  
 
@@ -275,7 +275,7 @@ You can run this script with any of the apps. If you're not running a fit, you p
 
 <h3>Fixed Oscillation Parameters Fits</h3>
 
-First, you may want to do a grid scan of oscillation parameters, running a fit at each step. In these fits, the oscillation parameters are fixed at the values for that point in the scan, and everything else is floated in a Minuit fit. We would normally do ~500 steps for each oscillation parameter, so 250,000 individual fits. Now, you can try submitting 250,000 jobs at once but do so at your own (and your friendly neighbourhood sys-admin's) peril! Instead, we we do one job for each value of one of the oscillation parameters, so that's 500 jobs each running 500 sequential fits. This number of course can be tuned for efficient running on your own cluster.
+First, you may want to do a grid scan of oscillation parameters, running a fit at each step. In these fits, the oscillation parameters are fixed at the values for that point in the scan, and everything else is floated in a Minuit fit. We would normally do ~500 steps for each oscillation parameter, so 250,000 individual fits. Now, you can try submitting 250,000 jobs at once but do so at your own (and your friendly neighbourhood sys-admin's) peril! Instead, we do one job for each value of one of the oscillation parameters, so that's 500 jobs each running 500 sequential fits. This number of course can be tuned for efficient running on your own cluster.
 
 There is a script, similar to `utils/submitCondor.py` but for submitting these fixed oscillation parameter fits. This is in `util/submitFixedOscJobs.py`. 
 

--- a/exec/llh_scan.cc
+++ b/exec/llh_scan.cc
@@ -48,6 +48,7 @@ void llh_scan(const std::string &fitConfigFile_,
   ParameterDict constrCorrs = fitConfig.GetConstrCorrs();
   std::map<std::string, std::string> constrCorrParName = fitConfig.GetConstrCorrParName();
   ParameterDict fdValues = fitConfig.GetFakeDataVals();
+  std::map<std::string, std::string> labelName = fitConfig.GetTexLabels();
 
   std::string pdfDir = outDir + "/unscaled_pdfs";
   std::string asimovDistDir = outDir + "/asimov_dists";
@@ -397,9 +398,9 @@ void llh_scan(const std::string &fitConfigFile_,
     double max = noms[name] + numStepsAboveNom * width;
 
     // Make histogram for this parameter
-    TString htitle = Form("%s, Asimov Rate: %f", name.c_str(), nom);
-    TH1D *hScan = new TH1D((name + "_full").c_str(), (name + "_full").c_str(), npoints, (min - (width / 2)) / nom, (max + (width / 2)) / nom);
-    hScan->SetTitle(std::string(htitle + ";" + name + " (rel. to Asimov); -(ln L_{full})").c_str());
+    TString htitle = Form("%s, Asimov Rate: %f", labelName[name].c_str(), nom);
+    TH1D *hScan = new TH1D((labelName[name] + "_full").c_str(), (labelName[name] + "_full").c_str(), npoints, (min - (width / 2)) / nom, (max + (width / 2)) / nom);
+    hScan->SetTitle(std::string(htitle + ";" + labelName[name] + " (rel. to Asimov); -(ln L_{full})").c_str());
 
     // Now loop from min to max in npoint steps
     for (int i = 0; i < npoints; i++)

--- a/src/util/DistBuilder.cc
+++ b/src/util/DistBuilder.cc
@@ -64,7 +64,7 @@ namespace antinufit
   }
 
   BinnedED
-  DistBuilder::BuildOscillatedDist(const std::string &name_, const int numDimensions_, const PDFConfig pdfConfig_, DataSet *data_, double deltam21_, double theta12_, std::unordered_map<int, double> indexDistance_, double& ratio)
+  DistBuilder::BuildOscillatedDist(const std::string &name_, const int numDimensions_, const PDFConfig pdfConfig_, DataSet *data_, double deltam21_, double sinsqth12_, std::unordered_map<int, double> indexDistance_, double& ratio)
   {
     // Create the axes
     AxisCollection axes = BuildAxes(pdfConfig_, numDimensions_);
@@ -83,7 +83,8 @@ namespace antinufit
       double nuEnergy = ev.GetDatum("nu_energy");
       int reacIndex = ev.GetDatum("reactorIndex");
       double baseline = indexDistance_[reacIndex];
-      double oscprob = antinufit::OscProb2(baseline, nuEnergy, deltam21_, sin(M_PI*theta12_/180)*sin(M_PI*theta12_/180));
+      //double oscprob = antinufit::OscProb2(baseline, nuEnergy, deltam21_, sin(M_PI*theta12_/180)*sin(M_PI*theta12_/180));
+      double oscprob = antinufit::OscProb2(baseline, nuEnergy, deltam21_, sinsqth12_);
       double r = rndm->Rndm();
       if (r > oscprob)
       {

--- a/util/plotFixedOscDist.C
+++ b/util/plotFixedOscDist.C
@@ -58,6 +58,15 @@ void plotFixedOscDist(const char *filename = "fit_results.root")
         tree->SetBranchAddress(branchName.c_str(), branchPointers[branchName]);
     }
 
+    // Check the form of theta 12
+    std::string theta12name;
+    if (tree->GetBranch("theta12"))
+        theta12name = "theta12";
+    else if (tree->GetBranch("sintheta12"))
+        theta12name = "sintheta12";
+    else if (tree->GetBranch("sinsqtheta12"))
+        theta12name = "sinsqtheta12";
+
     double minLLH = 1e9;
     double bestTheta = 0;
     double bestDeltaM = 0;
@@ -70,7 +79,7 @@ void plotFixedOscDist(const char *filename = "fit_results.root")
         if (branchValues["LLH"] < minLLH)
         {
             minLLH = branchValues["LLH"];
-            bestTheta = branchValues["theta12"];
+            bestTheta = branchValues[theta12name];
             bestDeltaM = branchValues["deltam21"];
         }
     }
@@ -106,8 +115,8 @@ void plotFixedOscDist(const char *filename = "fit_results.root")
     std::filesystem::path dirPath(filename);
     dirPath.replace_filename("");
     std::ostringstream directory;
-    directory << dirPath.string() << "/th" << std::fixed << std::setprecision(2) << bestTheta
-              << "/th" << std::fixed << std::setprecision(2) << bestTheta
+    directory << dirPath.string() << "/th" << std::fixed << std::setprecision(3) << bestTheta
+              << "/th" << std::fixed << std::setprecision(3) << bestTheta
               << "_dm" << std::fixed << std::setprecision(8) << bestDeltaM
               << "/postfit_dists/";
 

--- a/util/plotFixedOscLLH.C
+++ b/util/plotFixedOscLLH.C
@@ -181,9 +181,31 @@ void plotFixedOscLLH(const char *filename = "fit_results.root")
         return;
     }
 
+    // Check the form of theta 12
+    std::string theta12name = "";
+    std::string theta12label = "";
+    std::string theta12unit = "";
+    std::string theta12labelunit = "";
+    if (tree->GetBranch("theta12")){
+        theta12name = "theta12";
+        theta12label = "#theta_{12}";
+        theta12unit = "#circ";
+        theta12labelunit = theta12label + ", " + theta12unit;
+    }
+    else if (tree->GetBranch("sintheta12")){
+        theta12name = "sintheta12";
+        theta12label = "sin#theta_{12}";
+        theta12labelunit = theta12label;
+    }
+    else if (tree->GetBranch("sinsqtheta12")){
+        theta12name = "sinsqtheta12";
+        theta12label = "sin^{2}#theta_{12}";
+        theta12labelunit = theta12label;
+    }
+
     // Define variables to hold the tree branches
     double theta, deltam, llh;
-    tree->SetBranchAddress("theta12", &theta);
+    tree->SetBranchAddress(theta12name.c_str(), &theta);
     tree->SetBranchAddress("deltam21", &deltam);
     tree->SetBranchAddress("LLH", &llh);
 
@@ -194,11 +216,11 @@ void plotFixedOscLLH(const char *filename = "fit_results.root")
     int nBinsY = sqrt(nEntries);
     double minDeltam = tree->GetMinimum("deltam21");
     double maxDeltam = tree->GetMaximum("deltam21");
-    double minTheta = tree->GetMinimum("theta12");
-    double maxTheta = tree->GetMaximum("theta12");
+    double minTheta = tree->GetMinimum(theta12name.c_str());
+    double maxTheta = tree->GetMaximum(theta12name.c_str());
     double minLLH = tree->GetMinimum("LLH");
 
-    TH2D *hLLH = new TH2D("hLLH", "#Delta LLH;#Delta m^2, MeV;#theta",
+    TH2D *hLLH = new TH2D("hLLH", ("#Delta LLH;#Delta m^2, MeV;" + theta12labelunit).c_str(),
                           nBinsX, minTheta, maxTheta,
                           nBinsY, minDeltam, maxDeltam);
 
@@ -215,7 +237,7 @@ void plotFixedOscLLH(const char *filename = "fit_results.root")
     gPad->SetFrameLineWidth(2);
     gStyle->SetOptStat(0);
 
-    hLLH->GetXaxis()->SetTitle("#theta_{12}");
+    hLLH->GetXaxis()->SetTitle(theta12labelunit.c_str());
     hLLH->GetYaxis()->SetTitle("#Delta m^{2}_{21}, MeV");
     hLLH->GetYaxis()->SetTitleOffset(1.2);
     hLLH->GetZaxis()->SetTitle("2#Deltaln(L)");
@@ -263,7 +285,7 @@ void plotFixedOscLLH(const char *filename = "fit_results.root")
 
     Profile.first->Draw();
     Profile.first->SetLineColor(kBlack);
-    Profile.first->GetXaxis()->SetTitle("#theta_{12}");
+    Profile.first->GetXaxis()->SetTitle(theta12labelunit.c_str());
     Profile.first->GetYaxis()->SetTitle("2#Deltaln(L)");
     Profile.first->GetYaxis()->SetTitleOffset(1.2);
     Profile.first->SetTitle("");
@@ -290,8 +312,14 @@ void plotFixedOscLLH(const char *filename = "fit_results.root")
     latex.SetTextColor(kBlack);
     double left_sigma = thSigmas["bestfit"] - thSigmas["left"];
     double right_sigma = thSigmas["right"] - thSigmas["bestfit"];
-    latex.DrawLatex(thSigmas["right"] - 30, yMaxCanvas * 0.9, Form("#theta_{12} = %.2f#circ ^{+%.2f}_{-%.2f}", thSigmas["bestfit"], right_sigma, left_sigma));
 
+    double labelpos = 0;
+    if (theta12name == "theta12")
+        labelpos = 35;
+    else
+        labelpos = 0.4;
+
+    latex.DrawLatex(labelpos, yMaxCanvas * 0.9, Form("%s = (%.2f ^{+%.2f}_{-%.2f}) %s", theta12label.c_str(), thSigmas["bestfit"], right_sigma, left_sigma, theta12unit.c_str()));
     pathObj.replace_filename("theta12LLHDiff.pdf");
     c2->SaveAs(pathObj.string().c_str());
     outfile->cd();
@@ -333,7 +361,7 @@ void plotFixedOscLLH(const char *filename = "fit_results.root")
     latex.SetTextColor(kBlack);
     left_sigma = dmSigmas["bestfit"] - dmSigmas["left"];
     right_sigma = dmSigmas["right"] - dmSigmas["bestfit"];
-    latex.DrawLatex(dmSigmas["left"] - 0.000033, yMaxCanvas * 0.9, Form("#Deltam^{2}_{21} = %.3f^{+%.3f}_{-%.3f}#times10^{-5} eV^{2}", dmSigmas["bestfit"] * 1E5, right_sigma * 1E5, left_sigma * 1E5));
+    latex.DrawLatex(dmSigmas["left"] - 0.000033, yMaxCanvas * 0.9, Form("#Deltam^{2}_{21} = (%.3f^{+%.3f}_{-%.3f}) #times10^{-5} eV^{2}", dmSigmas["bestfit"] * 1E5, right_sigma * 1E5, left_sigma * 1E5));
 
     pathObj.replace_filename("deltam21LLHDiff.pdf");
     c3->SaveAs(pathObj.string().c_str());

--- a/util/submitFixedOscJobs.py
+++ b/util/submitFixedOscJobs.py
@@ -30,7 +30,7 @@ def read_fitcfg(fit_config):
         lines = file.readlines()
 
     for iline, line in enumerate(lines):
-        if line.startswith("[theta12]"):
+        if line.startswith("[theta12]") or line.startswith("[sintheta12]") or line.startswith("[sinsqtheta12]"):
             for jline in range(iline + 1, len(lines)):
                 if lines[jline].startswith("min ="):
                     theta_min = lines[jline].split("=")[1].strip()
@@ -97,7 +97,7 @@ def pycondor_submit(job_name, exec_name, out_dir, run_dir, env_file, fit_config,
         # Process the file and make updates
         for iline, line in enumerate(lines):
             # Update theta12 nom
-            if line.startswith("[theta12]"):
+            if line.startswith("[theta12]") or line.startswith("[sintheta12]") or line.startswith("[sinsqtheta12]"):
                 for jline in range(iline + 1, len(lines)):
                     if lines[jline].startswith("nom ="):
                         lines[jline] = f"nom = {theta}\n"
@@ -257,7 +257,7 @@ if __name__ == "__main__":
     for iJob in range(numvalstheta):
 
         theta = float(theta_min) + iJob*(float(theta_max)-float(theta_min))/numvalstheta
-        theta = "{:.2f}".format(theta)
+        theta = "{:.3f}".format(theta)
 
         batch_name = job_name + "_th{0}".format(theta)
 


### PR DESCRIPTION
In the fixed oscillation execs, we now check that there is a deltam21 parameter, and exactly one theta12, sintheta12, or sinsqtheta12 parameter (the naming is important). The user should have these specified in the config file.

The execs check which form of theta we're using, and hand the appropriate quantity to the oscillated distribution builder. 

The plotting scripts similarly check which form of theta was fitted, so the correct labels are used. Outputted directories are named with theta to 3sf not 2sf, so that 500 steps of 0 to 1 can be distinguished. 

Functionally everything works as it did, but if you try and run the updated plotting scripts on previously run fits, it will look for directories to 3sf, so be careful!

Asimov plots all still look reasonable in each of theta12, sin(theta12), sin^2(theta12)