### PR TITLE
Small Bug Fixes in LLH Scan and Plotting Scripts

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -353,11 +353,29 @@ This is just like `compareFixedOscParams` but it runs over 3 fits:
 
 > root -l 'util/compare3FixedOscParams.C("/path/to/fit1/params.root", "fit 1 label", "/path/to/fit2/params.root", "fit 2 label", "/path/to/fit3/params.root", "fit 3 label", "/path/to/output/file")'. 
 
+<h4>compare2LLHScans</h4>
+
+This script loops through the objects in the first of two LLH scan output files and prints each histogram to a canvas. If a histogram with the same name exists in the second LLH scan output files, these are drawn on the same canvas. Each canvas is saved as one page in a PDF file. You can run it with:
+
+> root -l 'util/compare2LLHScans.C("/path/to/llhscan1/llhscan.root", "/path/to/llhscan1/llhscan.root", "fit 1 label", "fit 2 label")'
+
 <h4>compare3LLHScans</h4>
 
-This script loops through the objects in the first of three LLH scan output files and prints each histogram to a canvas. If a histogram with the same name exists in the second and/or third LLH scan output files, these are drawn on the same canvas. Each canvas is saved as one page in a PDF file. You can run it with:
+This script is the same as `compare2LLHScans` but for three scans. It loops through the objects in the first LLH scan output file and prints each histogram to a canvas. If a histogram with the same name exists in the second and/or third LLH scan output files, these are drawn on the same canvas. Each canvas is saved as one page in a PDF file. You can run it with:
 
 > root -l 'util/compare3LLHScans.C("/path/to/llhscan1/llhscan.root", "/path/to/llhscan1/llhscan.root", "/path/to/llhscan3/llhscan.root", "fit 1 label", "fit 2 label", "fit 3 label")'
+
+<h4>plot1DPDFs</h4>
+
+This script loops through all the unscaled PDF files in a directory, and plots each on a different page of a PDF file. You can run it with:
+
+> root -l 'util/plot1DPDFs("/path/to/dir/")'
+
+<h4>compare1DPDFs</h4>
+
+This script loops through all the unscaled PDF files in a directory, and plots each on a different page of a PDF file. The user inputs the two directory paths, and labels for the legend. You can run it with:
+
+> root -l 'util/compare1DPDFs("/path/to/dir1/", "/path/to/dir2/", "label1", "label2")'
 
 <h3>MCMC</h3>
 

--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -248,8 +248,10 @@ void fixedosc_fit(const std::string &fitConfigFile_,
       dist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21, theta12_param, indexDistance, reactorRatio);
 
       // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
-      constrMeans[it->first] = constrMeans[it->first] * reactorRatio;
-      constrSigmas[it->first] = constrSigmas[it->first] * reactorRatio;
+      if (constrMeans.find(it->first) != constrMeans.end()){
+        constrMeans[it->first] = constrMeans[it->first] * reactorRatio;
+        constrSigmas[it->first] = constrSigmas[it->first] * reactorRatio;
+      }
       noms[it->first] = noms[it->first] * reactorRatio;
       mins[it->first] = mins[it->first] * reactorRatio;
       maxs[it->first] = maxs[it->first] * reactorRatio;

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -258,8 +258,10 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
 
       double noms_config = noms[it->first];
-      constrMeans[it->first] = constrMeans[it->first] * ratio;
-      constrSigmas[it->first] = constrSigmas[it->first] * ratio;
+      if (constrMeans.find(it->first) != constrMeans.end()){
+        constrMeans[it->first] = constrMeans[it->first] * ratio;
+        constrSigmas[it->first] = constrSigmas[it->first] * ratio;
+      }
       noms[it->first] = noms_config * ratio;
       mins[it->first] = mins[it->first] * ratio;
       maxs[it->first] = maxs[it->first] * ratio;
@@ -650,7 +652,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
 
   // Repeat for theta
   htitle = Form("%s, Nom. Value: %f", labelName[theta12name].c_str(), theta12_nom);
-  TH1D *hTheta12 = new TH1D("theta12_nom_full", (labelName[theta12name]  + "_nom_full").c_str(), npoints, (min - (width / 2)), (max + (width / 2)));
+  TH1D *hTheta12 = new TH1D(theta12name.c_str(), (labelName[theta12name]  + "_nom_full").c_str(), npoints, (min - (width / 2)), (max + (width / 2)));
   hTheta12->SetTitle(std::string(htitle + "; " + labelName[theta12name] + " (^{o}); -(ln L_{full})").c_str());
   std::cout << "Scanning for " << theta12name << std::endl;
   for (int iTheta12 = 0; iTheta12 < npoints; iTheta12++)

--- a/util/compare1DPDFs.C
+++ b/util/compare1DPDFs.C
@@ -1,0 +1,123 @@
+// ROOT Headers
+#include <TFile.h>
+#include <TTree.h>
+#include <TH2D.h>
+#include <TCanvas.h>
+#include <TStyle.h>
+
+// c++ Headers
+#include <sys/stat.h>
+
+/* ///////////////////////////////////////////////////////////////////
+///
+/// Script for comparing the unscaled PDFs inside 2 directories. The 
+/// inputs the directory names, and it loops through root files in 
+/// the first directory and plots the PDF histogram. It checks the 
+/// same file and histogram exist in the second directory, and then
+/// plots them on the same canvas. The plots are saved in a PDF file,
+/// with one PDF comparison on each page
+///
+/////////////////////////////////////////////////////////////////// */
+
+void compare1DPDFs(std::string dirname1, std::string dirname2, std::string label1, std::string label2)
+{
+    gStyle->SetOptStat(0);
+
+    std::vector<std::filesystem::path> pdfFiles;
+    std::string outputfilename = dirname1 + "/comppdfplots.pdf";
+
+    // Add files from the pdfs directory
+    for (const auto &entry : std::filesystem::directory_iterator(dirname1.c_str()))
+    {
+        pdfFiles.push_back(entry.path());
+    }
+
+     // Print file name to first page
+    TCanvas *c1 = new TCanvas("c1", "c1", 1500, 1080);
+    c1->SetTopMargin(0.1);
+    c1->SetBottomMargin(0.18);
+    c1->SetLeftMargin(0.15);
+    c1->SetRightMargin(0.09);
+    c1->SetGrid();
+    c1->SetFrameLineWidth(2);
+    c1->Print((outputfilename + "[").c_str());
+    c1->cd();
+
+    // Loop over each file
+    for (const auto &entry : pdfFiles)
+    {
+
+        std::string filePath1 = entry.string();
+        std::filesystem::path pathObj(filePath1);
+        // Check if it's a .root file
+        if (filePath1.find(".root") == std::string::npos)
+            continue;
+
+        std::string histName = pathObj.filename().replace_extension("");
+        TFile *file1 = TFile::Open(filePath1.c_str(), "READ");
+        if (!file1 || file1->IsZombie())
+        {
+            std::cerr << "Error opening file: " << filePath1 << std::endl;
+            delete file1;
+            continue;
+        }
+        // Get histogram
+        TH1D *h1 = nullptr;
+        file1->GetObject(histName.c_str(), h1);
+        if (!h1)
+        {
+            std::cerr << "No histogram " << histName << " found in file: " << filePath1 << std::endl;
+            file1->Close();
+            delete file1;
+            continue;
+        }
+
+        std::string filePath2 = dirname2 + "/" + pathObj.filename().string();
+        TFile *file2 = TFile::Open(filePath2.c_str(), "READ");
+        if (!file2 || file2->IsZombie())
+        {
+            std::cerr << "Error opening file: " << filePath2 << std::endl;
+            delete file2;
+            continue;
+        }
+        // Get histogram
+        TH1D *h2 = nullptr;
+        file2->GetObject(histName.c_str(), h2);
+        if (!h2)
+        {
+            std::cerr << "No histogram " << histName << " found in file: " << filePath2 << std::endl;
+            file2->Close();
+            delete file2;
+            continue;
+        }
+
+        h1->SetMaximum(1.3*h1->GetMaximum());
+        h1->SetLineWidth(2);
+        h1->SetLineColor(kBlue+2);
+        h1->GetXaxis()->SetTitleSize(0.055);
+        h1->GetYaxis()->SetTitleSize(0.055);
+        h1->GetXaxis()->SetLabelSize(0.045);
+        h1->GetYaxis()->SetLabelSize(0.045);
+        h1->GetYaxis()->SetTitle("Probability");
+        h1->SetTitle(histName.c_str());
+        h1->Draw();
+        h2->Draw("same");
+        h2->SetLineWidth(2);
+        h2->SetLineStyle(2);
+        h2->SetLineColor(kRed+1);
+        gPad->SetGrid(1);
+        gPad->Update();
+
+        TLegend *t1 = new TLegend(0.65, 0.73, 0.85, 0.88);
+        t1->AddEntry(h1, label1.c_str(), "l");
+        t1->AddEntry(h2, label2.c_str(), "l");
+        t1->SetLineWidth(2);
+        t1->SetTextFont(42);
+        t1->Draw();
+
+        c1->Print(outputfilename.c_str());
+    }
+
+    c1->Print((outputfilename + "]").c_str());
+
+}

--- a/util/compare2LLHScans.C
+++ b/util/compare2LLHScans.C
@@ -4,7 +4,7 @@
 
 /* ///////////////////////////////////////////////////////////////////
 ///
-/// Script for comparing 3 LLH scans.
+/// Script for comparing 2 LLH scans.
 ///
 /// The user inputs the root files made by fixedOscLLHScan for
 /// along with labels to be printed in the legend for
@@ -17,7 +17,7 @@
 ///
 /////////////////////////////////////////////////////////////////// */
 
-void LoopHistos(TDirectory *d1, TDirectory *d2, TDirectory *d3, std::string label1, std::string label2, std::string label3, std::string outfilename)
+void LoopHistos(TDirectory *d1, TDirectory *d2, std::string label1, std::string label2, std::string outfilename)
 {
 
   // Get the directory
@@ -50,6 +50,7 @@ void LoopHistos(TDirectory *d1, TDirectory *d2, TDirectory *d3, std::string labe
       c->SetFrameLineWidth(2);
 
       TH1D *plot1 = (TH1D *)d1->Get(name.c_str())->Clone();
+      plot1->SetName("plot1");
       plot1->GetYaxis()->SetTitleOffset(1.5);
       c->cd();
       plot1->SetLineColor(kBlack);
@@ -58,6 +59,7 @@ void LoopHistos(TDirectory *d1, TDirectory *d2, TDirectory *d3, std::string labe
       plot1->GetYaxis()->SetTitleSize(0.055);
       plot1->GetXaxis()->SetLabelSize(0.045);
       plot1->GetYaxis()->SetLabelSize(0.045);
+      plot1->SetMaximum(1.3*plot->GetMaximum());
       plot1->Draw();
       gPad->Update();
 
@@ -68,6 +70,8 @@ void LoopHistos(TDirectory *d1, TDirectory *d2, TDirectory *d3, std::string labe
         TH1D *hist2 = dynamic_cast<TH1D *>(obj2);
         if (hist2)
         {
+          plot2 = (TH1D *)hist2->Clone();
+          plot2->SetName("plot2");
           plot2->GetYaxis()->SetTitleOffset(1.5);
           c->cd();
           plot2->SetLineWidth(2);
@@ -80,26 +84,9 @@ void LoopHistos(TDirectory *d1, TDirectory *d2, TDirectory *d3, std::string labe
           plot2->Draw("same");
           gPad->Update();
         }
-      }
-
-      TObject *obj3 = d3->Get(name.c_str());
-      TH1D *plot3 = nullptr;
-      if (obj3)
-      {
-        TH1D *hist3 = dynamic_cast<TH1D *>(obj3);
-        if (hist3)
+        else
         {
-          plot3->GetYaxis()->SetTitleOffset(1.5);
-          c->cd();
-          plot3->SetLineWidth(2);
-          plot3->SetLineStyle(3);
-          plot3->SetLineColor(kBlue);
-          plot3->GetXaxis()->SetTitleSize(0.055);
-          plot3->GetYaxis()->SetTitleSize(0.055);
-          plot3->GetXaxis()->SetLabelSize(0.045);
-          plot3->GetYaxis()->SetLabelSize(0.045);
-          plot3->Draw("same");
-          gPad->Update();
+          continue;
         }
       }
 
@@ -107,26 +94,23 @@ void LoopHistos(TDirectory *d1, TDirectory *d2, TDirectory *d3, std::string labe
       t1->SetLineWidth(2);
       t1->AddEntry(plot1, label1.c_str(), "l");
       t1->AddEntry(plot2, label2.c_str(), "l");
-      t1->AddEntry(plot3, label3.c_str(), "l");
       t1->Draw("same");
 
       c->Print(outfilename.c_str());
       delete plot1;
       delete plot2;
-      delete plot3;
       delete c;
     }
   }
 }
 
-void compare3LLHScans(std::string filename1, std::string filename2, std::string filename3, std::string label1, std::string label2, std::string label3)
+void compare2LLHScans(std::string filename1, std::string filename2, std::string label1, std::string label2)
 {
 
   // Open file
   std::filesystem::path filepath1(filename1);
   TFile *f1 = new TFile(filename1.c_str(), "OPEN");
   TFile *f2 = new TFile(filename2.c_str(), "OPEN");
-  TFile *f3 = new TFile(filename3.c_str(), "OPEN");
   std::string outputfilename = filepath1.replace_extension("comp.pdf").string();
 
   // Aesthetics
@@ -138,7 +122,7 @@ void compare3LLHScans(std::string filename1, std::string filename2, std::string 
   c1->cd();
 
   // Now loop over all the histos and print each
-  LoopHistos(f1, f2, f3, label1, label2, label3, outputfilename);
+  LoopHistos(f1, f2, label1, label2, outputfilename);
 
   std::cout << "out the loop" << std::endl;
 

--- a/util/plot1DPDFs.C
+++ b/util/plot1DPDFs.C
@@ -1,0 +1,92 @@
+// ROOT Headers
+#include <TFile.h>
+#include <TTree.h>
+#include <TH2D.h>
+#include <TCanvas.h>
+#include <TStyle.h>
+
+// c++ Headers
+#include <sys/stat.h>
+
+/* ///////////////////////////////////////////////////////////////////
+///
+/// Script for plotting the unscaled PDFs inside a directory. The 
+/// inputs the directory name, and it loops through root files in that
+/// directory and plots the PDF histograms to a PDF file, one PDF on
+/// each page
+///
+/////////////////////////////////////////////////////////////////// */
+
+void plot1DPDFs(std::string dirname)
+{
+    gStyle->SetOptStat(0);
+
+    std::vector<std::filesystem::path> pdfFiles;
+    std::string outputfilename = dirname + "/pdfplots.pdf";
+
+    // Add files from the pdfs directory
+    for (const auto &entry : std::filesystem::directory_iterator(dirname.c_str()))
+    {
+        pdfFiles.push_back(entry.path());
+    }
+
+     // Print file name to first page
+    TCanvas *c1 = new TCanvas("c1", "c1", 1500, 1080);
+    c1->SetTopMargin(0.1);
+    c1->SetBottomMargin(0.18);
+    c1->SetLeftMargin(0.15);
+    c1->SetRightMargin(0.09);
+    c1->SetGrid();
+    c1->SetFrameLineWidth(2);
+    c1->Print((outputfilename + "[").c_str());
+    c1->cd();
+
+    // Loop over each file
+    for (const auto &entry : pdfFiles)
+    {
+
+        std::string filePath = entry.string();
+        std::filesystem::path pathObj(filePath);
+
+        // Check if it's a .root file
+        if (filePath.find(".root") == std::string::npos)
+            continue;
+
+        std::string histName = pathObj.filename().replace_extension("");
+
+        TFile *file = TFile::Open(filePath.c_str(), "READ");
+        if (!file || file->IsZombie())
+        {
+            std::cerr << "Error opening file: " << filePath << std::endl;
+            delete file;
+            continue;
+        }
+
+        // Get histogram
+        TH1D *h1 = nullptr;
+        file->GetObject(histName.c_str(), h1);
+
+        if (!h1)
+        {
+            std::cerr << "No histogram " << histName << " found in file: " << filePath << std::endl;
+            file->Close();
+            delete file;
+            continue;
+        }
+
+        h1->SetLineWidth(2);
+        h1->GetXaxis()->SetTitleSize(0.055);
+        h1->GetYaxis()->SetTitleSize(0.055);
+        h1->GetXaxis()->SetLabelSize(0.045);
+        h1->GetYaxis()->SetLabelSize(0.045);
+        h1->GetYaxis()->SetTitle("Probability");
+        h1->SetTitle(histName.c_str());
+        h1->Draw();
+        gPad->SetGrid(1);
+        gPad->Update();
+        c1->Print(outputfilename.c_str());
+    }
+
+    c1->Print((outputfilename + "]").c_str());
+
+}


### PR DESCRIPTION
In the fixed osc execs, we do `constrMeans[it->first] = constrMeans[it->first] * reactorRatio;` for the reactor PDF, but if we don't have a reactor constraint this makes the element in the map (and it defaults to 0). This fix avoids that by checking `constrMeans[it->first]` exists first

I also add more plotting scripts for comparing LLH scans and PDFs 