### PR TITLE
Add Padding back into Fixed Osc Execs

### DIFF
--- a/exec/fixedosc_fit.cc
+++ b/exec/fixedosc_fit.cc
@@ -264,6 +264,8 @@ void fixedosc_fit(const std::string &fitConfigFile_,
       dist = DistBuilder::Build(it->first, num_dimensions, pdfConfig, dataSet);
       fakeDataDist = DistBuilder::Build(it->first, num_dimensions, pdfConfig, dataSet);
     }
+    dist.AddPadding();
+    fakeDataDist.AddPadding();
 
     // Save the generated number of events for Beeston Barlow
     genRates.push_back(dist.Integral());

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -652,8 +652,9 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
 
   // Repeat for theta
   htitle = Form("%s, Nom. Value: %f", labelName[theta12name].c_str(), theta12_nom);
-  TH1D *hTheta12 = new TH1D(theta12name.c_str(), (labelName[theta12name]  + "_nom_full").c_str(), npoints, (min - (width / 2)), (max + (width / 2)));
+  TH1D *hTheta12 = new TH1D((theta12name + "_full").c_str(), (labelName[theta12name]  + "_nom_full").c_str(), npoints, (min - (width / 2)), (max + (width / 2)));
   hTheta12->SetTitle(std::string(htitle + "; " + labelName[theta12name] + " (^{o}); -(ln L_{full})").c_str());
+
   std::cout << "Scanning for " << theta12name << std::endl;
   for (int iTheta12 = 0; iTheta12 < npoints; iTheta12++)
   {

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -254,7 +254,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
       else if (hasTheta12)
         theta12_param = sin(M_PI * theta12_nom / 180) * sin(M_PI * theta12_nom / 180);
       dist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21_nom, theta12_param, indexDistance, ratio);
-
+      dist.AddPadding();
       // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
 
       double noms_config = noms[it->first];
@@ -280,7 +280,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
         std::cout << "Loading " << it->second.GetPrunedPath() << " deltam21: " << deltam21 << ", " << theta12name << ": " << theta12_param << std::endl;
         BinnedED oscDist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21, theta12_param, indexDistance, ratio);
 
-        // Now we will scale the constraint on the unoscillated reactor flux by the ratio of the oscillated to unoscillated number of events
+        oscDist.AddPadding();
         oscDist.Normalise();
         oscPDFs.push_back(oscDist);
         // Apply nominal systematic variables to the oscillated distribution
@@ -312,6 +312,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
         std::cout << "Loading " << it->second.GetPrunedPath() << " deltam21: " << deltam21_nom << ", " << theta12name << ": " << theta12_param << std::endl;
         BinnedED oscDist = DistBuilder::BuildOscillatedDist(it->first, num_dimensions, pdfConfig, dataSet, deltam21_nom, theta12_param, indexDistance, ratio);
 
+        oscDist.AddPadding();
         oscDist.Normalise();
         oscPDFs.push_back(oscDist);
         // Apply nominal systematic variables to the oscillated distribution
@@ -335,6 +336,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
     {
       // For all other PDFs, just use Build
       dist = DistBuilder::Build(it->first, num_dimensions, pdfConfig, dataSet);
+      dist.AddPadding();
     }
 
     // Now make a fake data dist for the event type

--- a/util/compare2LLHScans.C
+++ b/util/compare2LLHScans.C
@@ -59,7 +59,7 @@ void LoopHistos(TDirectory *d1, TDirectory *d2, std::string label1, std::string 
       plot1->GetYaxis()->SetTitleSize(0.055);
       plot1->GetXaxis()->SetLabelSize(0.045);
       plot1->GetYaxis()->SetLabelSize(0.045);
-      plot1->SetMaximum(1.3*plot->GetMaximum());
+      plot1->SetMaximum(1.3*plot1->GetMaximum());
       plot1->Draw();
       gPad->Update();
 

--- a/util/compare3LLHScans.C
+++ b/util/compare3LLHScans.C
@@ -58,6 +58,7 @@ void LoopHistos(TDirectory *d1, TDirectory *d2, TDirectory *d3, std::string labe
       plot1->GetYaxis()->SetTitleSize(0.055);
       plot1->GetXaxis()->SetLabelSize(0.045);
       plot1->GetYaxis()->SetLabelSize(0.045);
+      plot1->SetMaximum(1.3*plot1->GetMaximum());
       plot1->Draw();
       gPad->Update();
 


### PR DESCRIPTION
Pack you marmalade sandwiches paddington is back!

When we fit in the alph-n classifier we get lots of empty bins so this just reintroduces padding

Oh and I extend the y axis range of the llh scan plots (unrelated)