### PR TITLE
Purge Speech Marks from Tex Names in PDFConfigLoader

### DIFF
--- a/src/config/PDFConfigLoader.cc
+++ b/src/config/PDFConfigLoader.cc
@@ -42,6 +42,16 @@ namespace antinufit
       ConfigLoader::Load(name, "n_bins", binCount);
       ConfigLoader::Load(name, "branch_name", branchName);
       ConfigLoader::Load(name, "tex_name", texName);
+
+      // Remove "" if it surrounds the tex name string from the config
+      size_t start = 0;
+      size_t end = texName.size() - 1;
+      if (texName[start] == '"' || texName[start] == '\'')
+        start++;
+      if (end > start && (texName[end] == '"' || texName[end] == '\''))
+        end--;
+        texName = texName.substr(start, end - start + 1);
+
       retVal.AddAxis(name, branchName, texName, binCount, min, max);
     }
     retVal.SetDataBranchNames(data_axes);


### PR DESCRIPTION
Just does what we already do for parameter tex names in the fit config, but for pdf tex names in the pdf config

Means we can use e.g #alpha without it thinking it's a comment because it's "#alpha" in the config, but then we strip the "" so they don't appear on axis titles etc