### PR TITLE
Second Birk's Constant Function

### DIFF
--- a/plotting/plotFixedOscDist.C
+++ b/plotting/plotFixedOscDist.C
@@ -370,6 +370,7 @@ void plotFixedOscDist(const char *filename = "fit_results.root", const int datas
 
     lower->cd();
     hMC->Divide(histMap["data"]);
+    hMC->SetFillStyle(0);
     hMC->GetYaxis()->SetRangeUser(0.9, 1.1);
     hMC->GetXaxis()->SetTitleFont(42);
     hMC->GetYaxis()->SetTitleFont(42);
@@ -387,7 +388,7 @@ void plotFixedOscDist(const char *filename = "fit_results.root", const int datas
     hMC->GetYaxis()->ChangeLabel(2, -1, -1, -1, -1, -1, " ");
     hMC->GetYaxis()->ChangeLabel(4, -1, -1, -1, -1, -1, " ");
     hMC->SetLineWidth(2);
-    hMC->Draw();
+    hMC->Draw("hist");
     c1->Update();
 
     struct stat st = {0};
@@ -447,7 +448,7 @@ void plotFixedOscDist(const char *filename = "fit_results.root", const int datas
     c2->Update();
 
     lower2->cd();
-    hMC->Draw();
+    hMC->Draw("hist");
 
     pathObj.replace_filename(("distgroup" + outsuffix + ".pdf").c_str());
     c2->SaveAs(pathObj.string().c_str());

--- a/src/syst/SystFactory.cc
+++ b/src/syst/SystFactory.cc
@@ -88,6 +88,12 @@ namespace antinufit
         return ((1 + (birks_const * obs_val)) / (1 + (params.at("birks_constant") * obs_val))) * obs_val;
       };
 
+      ScaleFunc BirksLaw2 = [](const ParameterDict &params, const double &obs_val)
+      {
+        const double birks_const = 0.074;
+        return ((1 + (birks_const * obs_val)) / (1 + (params.at("birks_constant2") * obs_val))) * obs_val;
+      };
+
       ScaleFunction *scale_func = new ScaleFunction("scale_function");
 
       if (function == "BirksLaw")
@@ -96,6 +102,14 @@ namespace antinufit
         scale_func->SetScaleFunction(BirksLaw, paramnamevec_);
         scale_func->RenameParameter(paramnamevec_.at(0), "birks_constant");
         ParameterDict params({{"birks_constant", paramvals_[paramnamevec_.at(0)]}});
+        scale_func->SetParameters(params);
+      }
+      else if (function == "BirksLaw2")
+      {
+
+        scale_func->SetScaleFunction(BirksLaw2, paramnamevec_);
+        scale_func->RenameParameter(paramnamevec_.at(0), "birks_constant2");
+        ParameterDict params({{"birks_constant2", paramvals_[paramnamevec_.at(0)]}});
         scale_func->SetParameters(params);
       }
       else


### PR DESCRIPTION
For the ScaleFunction systematic, the ScaleFunction needs to know which parameters it acts on, so we need to hard code the same function when we're using it on other parameters

We should probably try and make this better in OXO (or maybe there's already a better way to do this) but this works for now

Also don't plot the error bars on the distribution ratio plots as they look a bit messy