### PR TITLE
Ability to Fix Parameters

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -112,6 +112,7 @@ The name of these tables should be the name of the fit parameter.
 - `constraint_corr`: Correlation of this parameter to another
 - `constraint_corrparname`: Name of other parameter this parameter is correlated to. This must be another parameter defined and activated in this file. Both correlated parameters must have a `constraint_mean` and `constraint_sig` defined.
 - `fake_data_val`: Value to use to produce a fake dataset if `fake_data` is true in the Summary
+- `fix`: Whether or not parameter is fixed in the fit
 
 A note on HMCMC: There is currently the functionality to run some MCMC, followed by some HMCMC starting from the best fit points of the MCMC. However, this didn't give any improvement in results or efficiency over the straight MCMC. The functionality is preserved in case we ever want to use it in the future, but generally we'll just run MCMC, with a notional 1 step HMCMC ran to avoid problems with files not being created when they are expected to.
 It's likely in the future we'll just remove the functionality.
@@ -239,7 +240,7 @@ Now the time has come to run a fit. When we float the oscillation parameters, we
 
 > ./bin/fixedosc_fit cfg/fit_config.ini cfg/event_config.ini cfg/pdf_config.ini cfg/syst_config.ini cfg/oscgrid.ini
 
-The value of the oscillation parameters should be set in the `fit` config file. You will need to have a `deltam21` parameter, and exactly one `theta12`, `sintheta12`, or `sinsqtheta12` parameter. This performs a `Minuit` fit, with the oscillation parameters fixed at those values and the Minuit settings in the `fitCofig`. It will load up all the pdfs, systematics, data etc. and creates the likelihood object in the same way the `llh_scan` app does, and then runs a fit. A variety of output files are produced (if the `save_outputs` in the `fitConfig` is set).
+The value of the oscillation parameters should be set (and fixed) in the `fit` config file. You will need to have a `deltam21` parameter, and exactly one `theta12`, `sintheta12`, or `sinsqtheta12` parameter. This performs a `Minuit` fit, with the oscillation parameters fixed at those values and the Minuit settings in the `fitCofig`. It will load up all the pdfs, systematics, data etc. and creates the likelihood object in the same way the `llh_scan` app does, and then runs a fit. A variety of output files are produced (if the `save_outputs` in the `fitConfig` is set).
 
 `fit_results.txt` contains each parameter value for the maximum LLH point, and `fit_results.root` contains the vectors of parameter names, postfit values and uncertainties, and a covariance matrix.
 

--- a/exec/fixedosc_llhscan.cc
+++ b/exec/fixedosc_llhscan.cc
@@ -52,6 +52,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   ParameterDict constrCorrs = fitConfig.GetConstrCorrs();
   std::map<std::string, std::string> constrCorrParName = fitConfig.GetConstrCorrParName();
   ParameterDict fdValues = fitConfig.GetFakeDataVals();
+  std::map<std::string, bool> fixedPars = fitConfig.GetFixPars();
   std::map<std::string, std::string> labelName = fitConfig.GetTexLabels();
 
   std::string pdfDir = outDir + "/unscaled_pdfs";
@@ -226,7 +227,7 @@ void fixedosc_llhscan(const std::string &fitConfigFile_,
   }
   std::cout << std::endl;
 
-  PrintParams(mins, maxs, noms, constrMeans, constrSigmas, constrRatioMeans, constrRatioSigmas, constrRatioParName, constrCorrs, constrCorrParName, datasetPars);
+  PrintParams(mins, maxs, noms, constrMeans, constrSigmas, constrRatioMeans, constrRatioSigmas, constrRatioParName, constrCorrs, constrCorrParName, datasetPars, fixedPars);
 
   // Create the individual PDFs and Asimov components, for each dataset, and make the component LLH objects
   std::map<std::string, std::vector<BinnedED>> pdfMap;

--- a/exec/makeFixedOscTree.cc
+++ b/exec/makeFixedOscTree.cc
@@ -50,6 +50,7 @@ using namespace antinufit;
 /// of the fit results
 ///
 /////////////////////////////////////////////////////////////////// */
+
 // Function to overwrite the save_outputs bool and Minuit settings in a fit config file
 void overwriteSaveOutputsAndMinuitSettings(const std::string &filepath)
 {

--- a/plotting/compareContours.C
+++ b/plotting/compareContours.C
@@ -68,7 +68,7 @@ void compareContours(std::string filename1, std::string label1, std::string file
   
     hLLH2->SetLineColor(kRed+2);
     hLLH2->SetLineWidth(2);
-    hLLH2->SetLineStyle(1);
+    hLLH2->SetLineStyle(2);
     hLLH2->SetContour(1, contours);
 
     // Draw the histograms
@@ -82,7 +82,7 @@ void compareContours(std::string filename1, std::string label1, std::string file
     hLLH1->Draw("cont2");
     hLLH2->Draw("cont3 SAME");
 
-    TLegend *t1 = new TLegend(0.78, 0.8, 0.89, 0.88);
+    TLegend *t1 = new TLegend(0.77, 0.8, 0.89, 0.88);
     t1->AddEntry(hLLH1, label1.c_str(), "l");
     t1->AddEntry(hLLH2, label2.c_str(), "l");
     t1->SetLineWidth(2);

--- a/src/config/FitConfig.cc
+++ b/src/config/FitConfig.cc
@@ -259,6 +259,12 @@ namespace antinufit
     return fConstrCorrs;
   }
 
+  std::map<std::string, bool>
+  FitConfig::GetFixPars() const
+  {
+    return fFixPars;
+  }
+
   std::map<std::string, std::string>
   FitConfig::GetConstrCorrParName() const
   {
@@ -279,18 +285,18 @@ namespace antinufit
 
   void
   FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_,
-                          std::string label_, double constrMean_, double constrSigma_)
+                          std::string label_, bool fixed_, double constrMean_, double constrSigma_)
   {
 
     fConstrMeans[name_] = constrMean_;
     fConstrSigmas[name_] = constrSigma_;
 
-    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_, label_);
+    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_, label_, fixed_);
   }
 
   void
   FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_,
-                          std::string label_)
+                          std::string label_, bool fixed_)
   {
     fMinima[name_] = min_;
     fMaxima[name_] = max_;
@@ -299,23 +305,24 @@ namespace antinufit
     fSigmas[name_] = sigma_;
     fNbins[name_] = nbins_;
     fTexLabels[name_] = label_;
+    fFixPars[name_] = fixed_;
   }
 
   void
   FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_,
-                          std::string label_, double constrRatioMean_, double constrRatioSigma_, std::string constrRatioParName_)
+                          std::string label_, bool fixed_, double constrRatioMean_, double constrRatioSigma_, std::string constrRatioParName_)
   {
 
     fConstrRatioMeans[name_] = constrRatioMean_;
     fConstrRatioSigmas[name_] = constrRatioSigma_;
     fConstrRatioParName[name_] = constrRatioParName_;
 
-    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_, label_);
+    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_, label_, fixed_);
   }
 
   void
   FitConfig::AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fdvalue_,
-                          std::string label_, double constrMean_, double constrSigma_, std::string constrCorrParName_, double constrCorr_)
+                          std::string label_, bool fixed_, double constrMean_, double constrSigma_, std::string constrCorrParName_, double constrCorr_)
   {
 
     fConstrMeans[name_] = constrMean_;
@@ -323,6 +330,6 @@ namespace antinufit
     fConstrCorrParName[name_] = constrCorrParName_;
     fConstrCorrs[name_] = constrCorr_;
 
-    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_, label_);
+    AddParameter(name_, nom_, min_, max_, sigma_, nbins_, fdvalue_, label_, fixed_);
   }
 }

--- a/src/config/FitConfig.hh
+++ b/src/config/FitConfig.hh
@@ -28,6 +28,8 @@ namespace antinufit
     ParameterDict GetConstrCorrs() const;
     std::map<std::string, std::string> GetConstrCorrParName() const;
 
+    std::map<std::string, bool> GetFixPars() const;
+
     int GetIterations() const;
     void SetIterations(int);
     int GetHMCIterations() const;
@@ -45,12 +47,12 @@ namespace antinufit
     std::string GetMinuitMethod() const;
     void SetMinuitMethod(std::string);
 
-    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_);
-    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_,
+    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_, bool fixed);
+    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_, bool fixed,
                       double constrMean_, double constrSigma_);
-    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_,
+    void AddParameter(const std::string &name_, double mean_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_, bool fixed,
                       double constrMean_, double constrSigma_, std::string constrCorrParName_, double constrCorr_);
-    void AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_,
+    void AddParameter(const std::string &name_, double nom_, double min_, double max_, double sigma_, int nbins_, double fakedata_, std::string label_, bool fixed,
                       double constrRatioMean_, double constrRatioSigma_, std::string constrRatioParName_);
 
     std::set<std::string> GetParamNames() const;
@@ -113,6 +115,7 @@ namespace antinufit
     bool fSaveOutputs;
     std::map<std::string, std::string> fConstrRatioParName;
     std::map<std::string, std::string> fConstrCorrParName;
+    std::map<std::string, bool> fFixPars;
   };
 }
 #endif

--- a/src/config/FitConfigLoader.cc
+++ b/src/config/FitConfigLoader.cc
@@ -106,6 +106,7 @@ namespace antinufit
     double constrCorr;
     std::string constrCorrParName;
     int nbins;
+    bool fixed;
 
     if (std::find(toLoad.begin(), toLoad.end(), "all") != toLoad.end())
     {
@@ -145,17 +146,26 @@ namespace antinufit
 
       try
       {
+        ConfigLoader::Load(name, "fix", fixed);
+      }
+      catch(const ConfigFieldMissing &e_)
+      {
+        fixed = false;
+      }
+
+      try
+      {
         ConfigLoader::Load(name, "constraint_mean", constrMean);
         ConfigLoader::Load(name, "constraint_sigma", constrSigma);
         try
         {
           ConfigLoader::Load(name, "constraint_corr", constrCorr);
           ConfigLoader::Load(name, "constraint_corrparname", constrCorrParName);
-          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, constrMean, constrSigma, constrCorrParName, constrCorr);
+          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, fixed, constrMean, constrSigma, constrCorrParName, constrCorr);
         }
         catch (const ConfigFieldMissing &e_)
         {
-          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, constrMean, constrSigma);
+          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, fixed, constrMean, constrSigma);
         }
       }
       catch (const ConfigFieldMissing &e_)
@@ -165,11 +175,11 @@ namespace antinufit
           ConfigLoader::Load(name, "constraint_ratiomean", constrRatioMean);
           ConfigLoader::Load(name, "constraint_ratiosigma", constrRatioSigma);
           ConfigLoader::Load(name, "constraint_ratioparname", constrRatioParName);
-          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, constrRatioMean, constrRatioSigma, constrRatioParName);
+          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, fixed, constrRatioMean, constrRatioSigma, constrRatioParName);
         }
         catch (const ConfigFieldMissing &e_)
         {
-          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel);
+          ret.AddParameter(name, nom, min, max, sig, nbins, fakeDataVal, texLabel, fixed);
         }
       }
     }

--- a/src/util/Utilities.cc
+++ b/src/util/Utilities.cc
@@ -154,7 +154,8 @@ namespace antinufit
 
     void PrintParams(ParameterDict mins, ParameterDict maxs, ParameterDict noms, ParameterDict constrMeans, ParameterDict constrSigmas,
                      ParameterDict constrRatioMeans, ParameterDict constrRatioSigmas, std::map<std::string, std::string> constrRatioParName,
-                     ParameterDict constrCorrs, std::map<std::string, std::string> constrCorrParName, std::map<std::string, std::vector<std::string>> datasets)
+                     ParameterDict constrCorrs, std::map<std::string, std::string> constrCorrParName, std::map<std::string, std::vector<std::string>> datasets,
+                     std::map<std::string, bool> fixPars)
     {
 
         std::vector<std::string> *tempNamesVec = new std::vector<std::string>{"deltam21",
@@ -180,7 +181,7 @@ namespace antinufit
 
         std::cout << std::endl;
         std::cout << "************** Fit Parameters **************" << std::endl;
-        std::cout << " -----------------------------------------------------------------------------------------------------------------------------------------------" << std::endl;
+        std::cout << " -------------------------------------------------------------------------------------------------------------------------------------------------------" << std::endl;
         std::cout << "| ";
         std::cout << std::left << std::setw(25) << "Name";
         std::cout << "| ";
@@ -195,8 +196,10 @@ namespace antinufit
         std::cout << std::left << std::setw(20) << "Constraint Mean";
         std::cout << "| ";
         std::cout << std::left << std::setw(20) << "Constraint Sigma";
+        std::cout << "| ";
+        std::cout << std::left << std::setw(6) << "Fixed";
         std::cout << "| " << std::endl;
-        std::cout << " ===============================================================================================================================================" << std::endl;
+        std::cout << " =======================================================================================================================================================" << std::endl;
         for (int iParam = 0; iParam < tempNamesVec->size(); iParam++)
         {
 
@@ -233,10 +236,12 @@ namespace antinufit
                 std::cout << std::left << std::setw(20) << "" << "| ";
                 std::cout << std::left << std::setw(20) << "" << "| ";
             }
+            std::cout << std::left << std::setw(6) << fixPars[tempNamesVec->at(iParam)];
+            std::cout << "| ";
             std::cout << std::endl;
         }
 
-        std::cout << " -----------------------------------------------------------------------------------------------------------------------------------------------" << std::endl;
+        std::cout << " -------------------------------------------------------------------------------------------------------------------------------------------------------" << std::endl;
         if (constrRatioMeans.size() > 0)
         {
             std::cout << std::endl;

--- a/src/util/Utilities.hh
+++ b/src/util/Utilities.hh
@@ -24,7 +24,8 @@ namespace antinufit
   std::pair<size_t, size_t> GetLowerUpperIndices(const std::vector<double>, double);
   std::vector<std::string> SplitString(const std::string &, char);
   void PrintParams(ParameterDict, ParameterDict, ParameterDict, ParameterDict, ParameterDict, ParameterDict, ParameterDict,
-                   std::map<std::string, std::string>, ParameterDict, std::map<std::string, std::string>, std::map<std::string, std::vector<std::string>>);
+                   std::map<std::string, std::string>, ParameterDict, std::map<std::string, std::string>, std::map<std::string, std::vector<std::string>>,
+                   std::map<std::string, bool>);
   std::string stripQuoteMarks(std::string);
 }
 #endif


### PR DESCRIPTION
Instead of ignoring the oscillation parameters in the fit, we now include them but have them fixed. This allows us to apply constraints on them easily.

User invokes "fix=1/0" in the fit config (defaults to 0) for any parameter